### PR TITLE
added patch for commerce kickstart install removing demo data

### DIFF
--- a/aegir/patches/commerce_kickstart.patch
+++ b/aegir/patches/commerce_kickstart.patch
@@ -1,10 +1,13 @@
-diff -urp a/commerce_kickstart.info b/commerce_kickstart.info
---- a/commerce_kickstart.info	2011-06-21 09:21:55.000000000 -0400
-+++ b/commerce_kickstart.info	2011-07-12 04:54:32.000000000 -0400
-@@ -1,5 +1,6 @@
- name = Commerce Kickstart
- description = Install with Drupal Commerce pre-configured for use.
-+old_short_name = commercedev
- core = 7.x
- 
- dependencies[] = block
+diff --git a/commerce_kickstart.install b/commerce_kickstart.install
+index 238f3e6..37f55f8 100644
+--- a/commerce_kickstart.install
++++ b/commerce_kickstart.install
+@@ -203,7 +203,7 @@ function commerce_kickstart_configure_store_form() {
+     '#title' => st('Do you want to install the demo store?'),
+     '#description' => st('Shows you everything Commerce Kickstart can do. Includes a custom theme, sample content and products.'),
+     '#options' => $options,
+-    '#default_value' => '1',
++    '#default_value' => '0',
+   );
+   $form['localization'] = array(
+     '#type' => 'fieldset',


### PR DESCRIPTION
I've been reading about how to use Commerce Kickstart 2.x with BOA, and seems like it's a real hassle owing to the strange way that demo data is incorporated. I'm wondering if it would be possible to patch Commerce Kickstart so that the demo data isn't automatically installed? Am I correct that this patch should be automatically applied to the commerce_kickstart distribution in the Octopus platform? And that the old_short_name is no longer needed? If so, the change seems to allow new commerce kickstart sites to be installed without demo data. I got the idea from https://www.drupal.org/node/2191205.

Also if you could tell me how to test things like this, it would be great. First time trying to contribute to this project.