### PR TITLE
Make fix_locales work on Debian

### DIFF
--- a/BARRACUDA.sh.txt
+++ b/BARRACUDA.sh.txt
@@ -2790,10 +2790,19 @@ fix_locales () {
 
 EOF
     sleep 5
-    locale-gen en_US en_US.UTF-8 &> /dev/null
-    update-locale &> /dev/null
-    localedef -v -c -i en_US -f UTF-8 en_US.UTF-8 &> /dev/null
-    echo "LANG=en_US.UTF-8" > /etc/default/locale
+    if [ "$_THIS_OS" = "Debian" ] ; then
+      _LOCALE_GEN_TEST=$(grep -v "^#" /etc/locale.gen 2>&1)
+      if [[ ! "$_LOCALE_GEN_TEST" =~ "en_US.UTF-8 UTF-8" ]] ; then
+        echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+      fi
+      locale-gen &> /dev/null
+      update-locale LANG=en_US.UTF-8 &> /dev/null
+    else
+      locale-gen en_US en_US.UTF-8 &> /dev/null
+      update-locale &> /dev/null
+      localedef -v -c -i en_US -f UTF-8 en_US.UTF-8 &> /dev/null
+      echo "LANG=en_US.UTF-8" > /etc/default/locale
+    fi
     if [ -e "/opt/tmp/$_BOA_REPO_NAME/aegir/conf/boa.bashrc.txt" ] ; then
       cp -af /root/.bashrc /root/.bashrc.bak.$_NOW
       cp -af /opt/tmp/$_BOA_REPO_NAME/aegir/conf/boa.bashrc.txt /root/.bashrc


### PR DESCRIPTION
I found the problems we were having with locales not getting fixed by BOA: on Debian, locale-gen does not take any arguments (this is Ubuntu-specific) and you have to edit /etc/locale.gen instead. Issues: #351 and #396.

I've also used `update-locale LANG=en_US.UTF-8` instead of echoing into /etc/default/locale. This works at least on Debian. I'm not sure about Ubuntu so I haven't changed it there. I've also omitted localedef, since according to the man page this is already called by locale-gen (and this seems to work).
