### PR TITLE
Update minimum RAM requirement to 1 GB

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -106,7 +106,7 @@ NOTE: BOA maintainers currently use only Debian based 64bit systems/servers.
 * Wget must be installed.
 * The Git standard port 9418 must be open.
 * SMTP standard port 25 (or SMTP relay) must be open for outgoing connections.
-* Minimum 512 MB of RAM (1 GB for heavy distros, like Atrium 2, Commerce etc.)
+* Minimum 1 GB of RAM
 * Locales with UTF-8 support, otherwise en_US.UTF-8 (default) is forced.
 * Basic sysadmin skills and experience.
 * Willingness to accept BOA PI (paranoid idiosyncrasies).


### PR DESCRIPTION
I assumed 512 MB of RAM was enough for a regular installation (issue #417), let's add a note to the README that it might not be enough.
