### PR TITLE
Improve locales consistency

### DIFF
--- a/BARRACUDA.sh.txt
+++ b/BARRACUDA.sh.txt
@@ -2858,12 +2858,21 @@ EOF
       cp -af /opt/tmp/$_BOA_REPO_NAME/aegir/conf/boa.bashrc.txt /root/.bashrc
       set_xterm
     fi
-    echo "export LANG=en_US.UTF-8" >> /root/.bashrc
-    echo "export LANGUAGE=en_US.UTF-8" >> /root/.bashrc
-    echo "export LC_ALL=\"\"" >> /root/.bashrc
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US.UTF-8
-    export LC_ALL=""
+    export LC_CTYPE=en_US.UTF-8
+    export LC_COLLATE=POSIX
+    export LC_NUMERIC=en_US.UTF-8
+    export LC_TIME=en_US.UTF-8
+    export LC_MONETARY=en_US.UTF-8
+    export LC_MESSAGES=en_US.UTF-8
+    export LC_PAPER=en_US.UTF-8
+    export LC_NAME=en_US.UTF-8
+    export LC_ADDRESS=en_US.UTF-8
+    export LC_TELEPHONE=en_US.UTF-8
+    export LC_MEASUREMENT=en_US.UTF-8
+    export LC_IDENTIFICATION=en_US.UTF-8
+    export LC_ALL=
   else
     if [ -e "/opt/tmp/$_BOA_REPO_NAME/aegir/conf/boa.bashrc.txt" ] ; then
       cp -af /root/.bashrc /root/.bashrc.bak.$_NOW


### PR DESCRIPTION
I've been doing some more reading and testing as follow-up to #398, and I think we can make some further improvements to locale handling.

There are some potential locale-related problems:
1. Regular expressions and LC_COLLATE
   After reading [this explanation](http://unix.stackexchange.com/a/149129/20865), I believe we should enforce `LC_COLLATE=POSIX`:
   LC_COLLATE impacts e.g. regular expressions, and since it can be overridden by an SSH client's settings, a default should be enforced and set to C or POSIX (these are equivalent).
   
   I've done [this test](http://unix.stackexchange.com/q/15980/20865) on several systems, and at least on some the collation order is problematic:
   
   `root@boa1:~# echo B | LC_COLLATE=en_US grep '[a-z]'`
   `B`
   
   While the  Ubuntu and Debian 7 systems I tested did not show this behavior, Debian 6 on DigitalOcean does, for example.
2. LC_ environment variables take precedence over LANG
   If locales are not UTF-8, the installer configures LANG and LANGUAGE as en_US.UTF-8 (and LC_ALL as empty) on the fly using `export`. While this overrides the LANG variable, LC_\* environment variables take precedence over LANG, so we should define the important ones as defaults in /etc/default/locale (LC_CTYPE and LC_COLLATE).
   (I think enforcing the desired LC_ variables explicitly is preferable to disabling `AcceptEnv LANG LC_*` in sshd_config).
   During installation we should then set **all** LC_\* variables to en_US.UTF-8 on-the-fly for "broken" systems (except LC_COLLATE=POSIX, so we cannot use LC_ALL here), because otherwise we may still end up with locale error message throughout the installer log. ("Cannot set LC_ALL to default locale: No such file or directory", etc..)

I believe these changes improve upon the current handling. Some minor other changes:
- Simplified generating locales in Ubuntu (tested on 10.04 and 12.04)
- Added the "Remove empty lines from /etc/locale.gen" commit for consistency with the other section in fix_locales
- Only exporting the LANG and LC_ variables seems sufficient (without echoing into /root/.bashrc)

Maybe:
- Also define a default for LC_NUMERIC?
- The fix_locales command is run three times in total. Is there a particular reason for that? I've tested the installer with just the first call to fix_locales, and that worked.
- Maybe add instructions to the _LOCALE_TEST=BROKEN message to install extra locales (as required by your SSH client) yourself after the installer has finished. Or, possibly enforce en_US.UTF-8 for all LC_ variables?

Let me know what you think, and if I should maybe change or fix anything in the pull request!
