### PR TITLE
Update for PHP-FPM socket

### DIFF
--- a/aegir/conf/nginx_compact_include.conf
+++ b/aegir/conf/nginx_compact_include.conf
@@ -35,7 +35,7 @@ location ~ \.php$ {
   tcp_nopush off;
   keepalive_requests 0;
   try_files $uri =404;            ### check for existence of php file first
-  fastcgi_pass 127.0.0.1:9090;
+  fastcgi_pass unix:/var/run/www53.fpm.socket;
 }
 
 ###


### PR DESCRIPTION
BOA changed from port to socket but this one is left.

Forgotten or for a reason?
