### PR TITLE
Prevent 'Could not change permissions' warnings with CiviCRM

### DIFF
--- a/aegir/tools/system/daily.sh
+++ b/aegir/tools/system/daily.sh
@@ -1549,7 +1549,7 @@ fix_permissions () {
     find $Dir/files/* -type f -exec chmod 0664 {} \; &> /dev/null
     chmod 02775 $Dir/files &> /dev/null
     chown $_THIS_HM_USER:www-data $Dir/files &> /dev/null
-    chown $_THIS_HM_USER:www-data $Dir/files/{tmp,images,pictures,css,js,advagg_css,advagg_js,ctools,ctools/css,imagecache,locations,xmlsitemap,deployment,styles,private} &> /dev/null
+    chown $_THIS_HM_USER:www-data $Dir/files/{tmp,images,pictures,css,js,advagg_css,advagg_js,ctools,ctools/css,imagecache,locations,xmlsitemap,deployment,styles,private,civicrm,civicrm/templates_c,civicrm/upload,civicrm/persist,civicrm/custom,civicrm/dynamic} &> /dev/null
     ### private - site level
     chown -L -R ${_THIS_HM_USER}.ftp:www-data $Dir/private &> /dev/null
     find $Dir/private -type d -exec chmod 02775 {} \; &> /dev/null


### PR DESCRIPTION
I was getting messages like `"Could not change permissions <...>/files/civicrm/templates_c to 2770 (chmod to 2770 failed on <...>/files/civicrm/templates_c)` when verifying sites with CiviCRM installed. I'd like the nice green status back :)

Similar to [this previous issue](https://www.drupal.org/node/1920972).

Untested but this should work. Note there's also a `civicrm/ConfigAndLog` folder, but I'm not getting warnings for that one. Should it also be changed?
