### PR TITLE
Add support for multivalued fields in SOLR 4.

### DIFF
--- a/aegir/tools/system/conf/solr/apachesolr/7/schema.xml
+++ b/aegir/tools/system/conf/solr/apachesolr/7/schema.xml
@@ -325,6 +325,12 @@
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldType="tdouble"/>
 
+    <!-- A specialized field for geospatial search. If indexed, this fieldType can be multivalued. -->
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+           distErrPct="0.025"
+           maxDistErr="0.000009"
+           units="degrees" />
+
     <!-- A Geohash is a compact representation of a latitude longitude pair in a single field.
          See http://wiki.apache.org/solr/SpatialSearch
      -->
@@ -509,7 +515,7 @@
     <dynamicField name="points_*" type="point" indexed="true"  stored="true" multiValued="false"/>
     <dynamicField name="pointm_*" type="point" indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="locs_*" type="location" indexed="true"  stored="true" multiValued="false"/>
-    <dynamicField name="locm_*" type="location" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="locm_*" type="location_rpt" indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="geos_*" type="geohash" indexed="true"  stored="true" multiValued="false"/>
     <dynamicField name="geom_*" type="geohash" indexed="true"  stored="true" multiValued="true"/>
 

--- a/aegir/tools/system/conf/solr/search_api_solr/7/schema.xml
+++ b/aegir/tools/system/conf/solr/search_api_solr/7/schema.xml
@@ -325,6 +325,12 @@
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldType="tdouble"/>
 
+    <!-- A specialized field for geospatial search. If indexed, this fieldType can be multivalued. -->
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+           distErrPct="0.025"
+           maxDistErr="0.000009"
+           units="degrees" />
+
     <!-- A Geohash is a compact representation of a latitude longitude pair in a single field.
          See http://wiki.apache.org/solr/SpatialSearch
      -->
@@ -509,7 +515,7 @@
     <dynamicField name="points_*" type="point" indexed="true"  stored="true" multiValued="false"/>
     <dynamicField name="pointm_*" type="point" indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="locs_*" type="location" indexed="true"  stored="true" multiValued="false"/>
-    <dynamicField name="locm_*" type="location" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="locm_*" type="location_rpt" indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="geos_*" type="geohash" indexed="true"  stored="true" multiValued="false"/>
     <dynamicField name="geom_*" type="geohash" indexed="true"  stored="true" multiValued="true"/>
 

--- a/docs/SOLR.txt
+++ b/docs/SOLR.txt
@@ -13,8 +13,8 @@ different versions of Apache Solr and Jetty server, for maximum backward and
 future compatibility.
 
 By default, all pre-configured Solr Cores come with required solrconfig.xml,
-schema.xml and protwords.txt files compatible with Solr 3.x config series from
-Search API Solr search module for Solr 3.x and Solr 4.x, or Solr 1.x config
+schema.xml and protwords.txt files compatible with Solr 4.x config series from
+Search API Solr search module for Solr 4.x, or Solr 1.x config
 series for Solr 1.x
 
 You may want to replace them if you wish to use Solr with Drupal 6 sites,


### PR DESCRIPTION
hi,

I came across this the other day for a project and I think it makes sense to support multiple valued location fields by default.

Config came from here : http://www.midwesternmac.com/blogs/jeff-geerling/multi-value-spatial-search

While searching BOA scripts I could not find any indication of special treatment between SOLR 3 or SOLR4 configuration. It seems to me that config for SOLR 4 is the default one but maybe I am missing something.

@omega8cc What do you think about this patch ?
