### PR TITLE
sqlmagic_fix: do not escape backslashes and EOL character inside strong quotes

### DIFF
--- a/aegir/tools/bin/sqlmagic
+++ b/aegir/tools/bin/sqlmagic
@@ -5,9 +5,9 @@ PATH=/usr/local/bin:/usr/local/sbin:/opt/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
 sqlmagic_fix() {
   if [ -f "$source" ]; then
     cat $source \
-      | sed 's|/\\*!50001 CREATE ALGORITHM=UNDEFINED \\*/|/\\*!50001 CREATE \\*/|g; \
-      s|/\\*!50017 DEFINER=`[^`]*`@`[^`]*`\s*\\*/||g' \
-      | sed '/\\*!50013 DEFINER=.*/ d' > $target
+      | sed 's|/\*!50001 CREATE ALGORITHM=UNDEFINED \*/|/\*!50001 CREATE \*/|g;
+      s|/\*!50017 DEFINER=`[^`]*`@`[^`]*`\s*\*/||g' \
+      | sed '/\*!50013 DEFINER=.*/ d' > $target
     sed -i "s/^INSERT INTO/INSERT IGNORE INTO/g" $target
     echo "Fixed database dump stored as $target"
     exit 0


### PR DESCRIPTION
Running `sqlmagic fix some_civicrm_db.sql` gave this error:

    sed: -e expression #1, char 125: unterminated address regex
    cat: write error: Broken pipe

This seems to be because of escaping the EOL character inside a strong-quoted expression. But with only that backslash removed, the expression for the `!50001 CREATE ALGORITHM=UNDEFINED` and `!50017 DEFINER` SQL statements are not actually replaced, while `!50013 DEFINER` and the `INSERT INTO` statements are fixed.

I changed the `\\*` to `\*` in all sqlmagic_fix expressions for consistency. This works.

I wonder if it'd be more readable to change the first sed expression to two separate ones?