### PR TITLE
Fix installation failure with D8 rest module

### DIFF
--- a/aegir/conf/php56.ini
+++ b/aegir/conf/php56.ini
@@ -702,7 +702,7 @@ default_charset = "UTF-8"
 ; If post reading is disabled through enable_post_data_reading,
 ; $HTTP_RAW_POST_DATA is *NOT* populated.
 ; http://php.net/always-populate-raw-post-data
-;always_populate_raw_post_data = -1
+always_populate_raw_post_data = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Paths and Directories ;


### PR DESCRIPTION
The core rest module's `hook_requirements()` implementation checks whether this ini value is not set to -1 and fails to install.