### PR TITLE
improve ffmpeg installation procedure

### DIFF
--- a/BARRACUDA.sh.txt
+++ b/BARRACUDA.sh.txt
@@ -371,6 +371,7 @@ nginx_wildcard_ssl
 ###
 ### Optional add-on services
 ###
+if_install_ffmpeg
 if_install_magick
 if_install_bzr
 if_install_ftpd

--- a/lib/functions/system.sh.inc
+++ b/lib/functions/system.sh.inc
@@ -2783,21 +2783,7 @@ install_with_aptitude_deps() {
   else
     _GPG=gpg
   fi
-  if [[ "${_XTRAS_LIST}" =~ "FMG" ]]; then
-    if [ "${_OSV}" = "jessie" ] \
-      || [ "${_OSV}" = "wheezy" ] \
-      || [ "${_DO_FIX}" = "YES" ] \
-      || [ "${_OSV}" = "trusty" ] \
-      || [ "${_OSV}" = "precise" ]; then
-      _EXTRA_APT="tree ffmpeg flvtool2 libavcodec-extra-53"
-    elif [ "${_OSV}" = "squeeze" ]; then
-      _EXTRA_APT="tree ffmpeg flvtool2 libavcodec52"
-    else
-      _EXTRA_APT="tree ffmpeg flvtool2 libavcodec51"
-    fi
-  else
-    _EXTRA_APT="tree"
-  fi
+  _EXTRA_APT="tree"
   st_runner "apt-get install ${_EXTRA_APT} ${nrmUpArg}" 2> /dev/null
   if [ -e "/etc/init.d/php5-fpm" ]; then
     mrun "service php5-fpm stop" &> /dev/null

--- a/lib/functions/xtra.sh.inc
+++ b/lib/functions/xtra.sh.inc
@@ -454,3 +454,57 @@ if_install_magick() {
     install_magick_src
   fi
 }
+
+if_install_ffmpeg() {
+  if [[ "${_XTRAS_LIST}" =~ "FMG" ]]; then
+    if [ ! -x "/usr/bin/ffmpeg" ]; then
+      echo " "
+      if prompt_yes_no "Do you want to install FFmpeg?" ; then
+        true
+        msg "INFO: Installing FFmpeg..."
+        cd /var/opt
+        if [ "${_OSV}" = "jessie" ] || [ "${_OSV}" = "wheezy" ]; then
+          echo "## deb-multimedia APT Repository for FFmpeg" > ${aptLiSys}.d/ffmpeg.list
+          if [ "${_OSV}" = "jessie" ]; then
+            echo "deb http://www.deb-multimedia.org jessie main non-free" >> ${aptLiSys}.d/ffmpeg.list
+            echo "deb http://www.deb-multimedia.org jessie-backports main" >> ${aptLiSys}.d/ffmpeg.list
+          elif [ "${_OSV}" = "wheezy" ]; then
+            echo "deb http://www.deb-multimedia.org wheezy main non-free" >> ${aptLiSys}.d/ffmpeg.list
+            echo "deb http://www.deb-multimedia.org wheezy-backports main" >> ${aptLiSys}.d/ffmpeg.list
+          fi
+          st_runner "apt-get update -qq" &> /dev/null
+          st_runner "${_INSTAPP} deb-multimedia-keyring" 2> /dev/null
+          st_runner "apt-get update -qq" &> /dev/null
+          st_runner "${_INSTAPP} ffmpeg" 2> /dev/null
+        elif [ "${_OSV}" = "squeeze" ] || [ "${_OSV}" = "trusty" ] || [ "${_OSV}" = "precise" ]; then
+          _X86_64_TEST=$(uname -m 2>&1)
+          rm -rf ffmpeg*
+          if [ "${_X86_64_TEST}" = "x86_64" ]; then
+            SYSTEMARCH="x86_64"
+            msg "INFO: Installing ffmpeg ${SYSTEMARCH}..."
+            curl ${crlGet} "http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz" -o "ffmpeg-release-64bit-static.tar.xz"
+            unxz "ffmpeg-release-64bit-static.tar.xz"
+            mkdir ffmpeg-release-64bit-static
+            tar -xf ffmpeg-release-64bit-static.tar --strip-components 1 -C ffmpeg-release-64bit-static
+            cd ffmpeg-release-64bit-static
+          else 
+            SYSTEMARCH="x86"
+            msg "INFO: Installing ffmpeg ${SYSTEMARCH}..."
+            curl ${crlGet} "http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz" -o "ffmpeg-release-32bit-static.tar.xz"
+            unxz "ffmpeg-release-32bit-static.tar.xz"
+            mkdir ffmpeg-release-32bit-static
+            tar -xf ffmpeg-release-32bit-static.tar --strip-components 1 -C ffmpeg-release-32bit-static
+            cd ffmpeg-release-32bit-static
+          fi
+          chown root:root {ffmpeg,ffmpeg-10bit,ffprobe,ffserver,qt-faststart}
+          chmod 755 {ffmpeg,ffmpeg-10bit,ffprobe,ffserver,qt-faststart}
+          cp -af {ffmpeg,ffmpeg-10bit,ffprobe,ffserver,qt-faststart} /usr/bin/
+          cd /var/opt
+        fi
+        msg "INFO: FFmpeg installed"
+      else
+        msg "INFO: FFmpeg installation skipped"
+      fi
+    fi
+  fi
+}


### PR DESCRIPTION
With this commit, we will use the real ffmpeg (as opposed to a libav symlink) for all supported BOA distros. 

- For Debian Jessie and Wheezy, deb-multimedia.org repositories are used
- For all other distros, static builds from http://johnvansickle.com/ffmpeg/ are utilized

Addresses #883

