### PR TITLE
add adminer database manager

### DIFF
--- a/BARRACUDA.sh.txt
+++ b/BARRACUDA.sh.txt
@@ -33,6 +33,7 @@
 ###
 ### Software versions
 ###
+_ADMINER_VRN=4.2.5
 _BZR_VRN=2.6.0
 _CGP_VRN=master-30-03-2014
 _CHIVE_VRN=1.3
@@ -376,6 +377,7 @@ if_install_magick
 if_install_bzr
 if_install_ftpd
 if_install_jetty
+if_install_adminer
 if_install_chive
 if_install_sqlbuddy
 if_install_collectd

--- a/README.txt
+++ b/README.txt
@@ -109,7 +109,7 @@ production settings.
 === Included/enabled by default - see docs/NOTES.txt for details
 
 * All libraries & tools required to install and run Nginx based Aegir system.
-* Latest release of MariaDB 5.5 or 10.0 database server with Chive manager.
+* Latest release of MariaDB 5.5 or 10.0 database server with Adminer manager.
 * Latest version of Nginx web server.
 * Letsencrypt.org SSL support - see docs/SSL.txt for details.
 * HTTPS access with self-signed certificate for all hosted sites.
@@ -147,6 +147,7 @@ production settings.
 * FFmpeg support.
 * Bind9 DNS server.
 * Webmin Control Panel.
+* Chive database manager
 * SQL Buddy database manager.
 * Collectd server monitor.
 * LDAP Nginx support via third-party module (experimental).

--- a/aegir/conf/nginx_sql_adminer.conf
+++ b/aegir/conf/nginx_sql_adminer.conf
@@ -1,0 +1,36 @@
+###
+### Adminer SQL Manager Redirect to HTTPS.
+###
+server {
+  listen                       127.0.0.1:80;
+  server_name                  adminer_name;
+  return 301 https://$host$request_uri;
+}
+
+###
+### Adminer SQL Manager HTTPS Only.
+###
+server {
+  include                      fastcgi_params;
+  fastcgi_param                SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  fastcgi_param                HTTPS on;
+  limit_conn                   limreq 555;
+  listen                       127.0.0.1:443;
+  server_name                  adminer_name;
+  ### access placeholder
+  root                         /var/www/adminer;
+  index                        index.php index.html;
+  ssl                          on;
+  ssl_dhparam                  /etc/ssl/private/nginx-wild-ssl.dhp;
+  ssl_certificate              /etc/ssl/private/nginx-wild-ssl.crt;
+  ssl_certificate_key          /etc/ssl/private/nginx-wild-ssl.key;
+  ssl_session_timeout          5m;
+  ssl_protocols                TLSv1.1 TLSv1.2;
+  ssl_ciphers                  ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+  ssl_prefer_server_ciphers    on;
+  keepalive_timeout            70;
+  if ($is_crawler) {
+    return 403;
+  }
+  include                      /var/aegir/config/includes/nginx_compact_include.conf;
+}

--- a/docs/MODULES.txt
+++ b/docs/MODULES.txt
@@ -56,6 +56,7 @@ Contrib [S]upported:
 
 Contrib [S]upported and [B]undled:
 
+ adminer -------------------- [D7] ------ [S] [B]
  advagg --------------------- [D6,D7] --- [S] [B]
  blockcache_alter ----------- [D6,D7] --- [S] [B]
  boost ---------------------- [D6,D7] --- [S] [B]

--- a/docs/NOTES.txt
+++ b/docs/NOTES.txt
@@ -6,8 +6,8 @@
     ###
     ### Xtras included with "ALL" wildcard:
     ###
+    ### ADM --- Adminer DB Manager
     ### CGP --- Collectd Graph Panel
-    ### CHV --- Chive DB Manager
     ### CSF --- Firewall
     ### CSS --- Compass Tools (available on Squeeze, Wheezy, Precise and Trusty)
     ### FTP --- Pure-FTPd server with forced FTPS
@@ -21,6 +21,7 @@
     ### BDD --- SQL Buddy DB Manager
     ### BND --- Bind9 DNS Server (available on Debian only)
     ### BZR --- Bazaar
+    ### CHV --- Chive DB Manager
     ### FMG --- FFmpeg support
     ### GIT --- Latest Git from sources
     ### IMG --- Image Optimize binaries: advdef advpng jpegoptim jpegtran optipng pngcrush pngquant
@@ -51,7 +52,7 @@
 
   * Your Aegir Master Instance control panel will be available at https://master.f-q-d-n
   * Your Fast DNS Cache Server (pdnsd) will listen on 127.0.0.1:53
-  * Your Chive MariaDB Manager will be available at https://chive.master.f-q-d-n
+  * Your Adminer MariaDB Manager will be available at https://adminer.master.f-q-d-n
   * Your CSF/LFD Firewall will support integrated Nginx Abuse Guard.
 
   NOTE: With _EASY_SETUP=NO option (default is PUBLIC) Barracuda will offer installation
@@ -59,6 +60,7 @@
 
   * Your Aegir Master Instance control panel will be available at https://master.f-q-d-n
   * Your Fast DNS Cache Server (pdnsd) will listen on 127.0.0.1:53
+  * Your (optional) Adminer MariaDB Manager will be available at https://adminer.master.f-q-d-n
   * Your (optional) Bind9 DNS Server will listen on 123.45.67.89:53
   * Your (optional) Chive MariaDB Manager will be available at https://chive.master.f-q-d-n
   * Your (optional) Collectd Graph Panel will be available at https://cgp.master.f-q-d-n
@@ -71,8 +73,8 @@
 
   NOTE: If your outgoing SMTP requires using relayhost, define _SMTP_RELAY_HOST first.
 
-  NOTE: Chive, SQL Buddy and Collectd will work only if chive. sqlbuddy. and cgp.
-        subdomains point to your IP (we recommend using wildcard DNS to simplify it).
+  NOTE: Adminer, Chive, SQL Buddy and Collectd will work only if adminer. chive. sqlbuddy. 
+        and cgp. subdomains point to your IP (we recommend using wildcard DNS to simplify it).
         But don't worry, you can add proper DNS entries for those subdomains later,
         if you didn't enable wildcard DNS before running Barracuda installer.
         Only system hostname must have proper DNS configuration before installing Barracuda.
@@ -88,7 +90,7 @@
 
   * Your Aegir Master Instance control panel will be available at https://aegir.local
   * Your Fast DNS Cache Server (pdnsd) will listen on 127.0.0.1:53
-  * Your Chive MariaDB Manager will be available at https://chive.aegir.local
+  * Your Adminer MariaDB Manager will be available at https://adminer.aegir.local
 
 
 # Notes related to Barracuda and Octopus customized install and upgrades

--- a/lib/functions/helper.sh.inc
+++ b/lib/functions/helper.sh.inc
@@ -276,7 +276,7 @@ mode_detection() {
     fi
     if [ "${_EASY_SETUP}" = "LOCAL" ]; then
       msg "INFO: Localhost Setup Mode Active"
-      _XTRAS_LIST="CHV"
+      _XTRAS_LIST="ADM"
       _AUTOPILOT=YES
       _DEBUG_MODE=NO
       _DB_SERVER=MariaDB
@@ -287,7 +287,7 @@ mode_detection() {
       _LOCAL_NETWORK_HN="aegir.local"
     elif [ "${_EASY_SETUP}" = "PUBLIC" ]; then
       msg "INFO: Public Setup Mode Active"
-      _XTRAS_LIST="CSF CHV FTP"
+      _XTRAS_LIST="CSF ADM FTP"
       _AUTOPILOT=YES
       _DEBUG_MODE=NO
       _DB_SERVER=MariaDB

--- a/lib/functions/satellite.sh.inc
+++ b/lib/functions/satellite.sh.inc
@@ -1413,6 +1413,9 @@ satellite_o_contrib_seven_update_global() {
         fi
       done
       cd ${_D}/$i/o_contrib_seven
+      if [ ! -d "${_D}/$i/o_contrib_seven/adminer" ]; then
+        get_dev_contrib "adminer-7.x-1.1.tar.gz"
+      fi
       if [ ! -d "${_D}/$i/o_contrib_seven/advagg" ]; then
         get_dev_contrib "advagg-7.x-2.18.tar.gz"
       fi
@@ -1516,6 +1519,7 @@ satellite_download_o_contrib_seven() {
     msg "${_STATUS} A: Downloading o_contrib_seven modules..."
   fi
   get_dev_contrib "admin-7.x-2.0-beta3.tar.gz"
+  get_dev_contrib "adminer-7.x-1.1.tar.gz"
   get_dev_contrib "advagg-7.x-2.18.tar.gz"
   get_dev_contrib "blockcache_alter-7.x-1.x-dev.tar.gz"
   get_dev_contrib "boost-7.x-1.1.tar.gz"

--- a/lib/functions/satellite.sh.inc
+++ b/lib/functions/satellite.sh.inc
@@ -1415,6 +1415,13 @@ satellite_o_contrib_seven_update_global() {
       cd ${_D}/$i/o_contrib_seven
       if [ ! -d "${_D}/$i/o_contrib_seven/adminer" ]; then
         get_dev_contrib "adminer-7.x-1.1.tar.gz"
+        curl ${crlGet} "https://www.adminer.org/static/download/${_ADMINER_VRN}/adminer-${_ADMINER_VRN}.php" -o "${_D}/$i/o_contrib_seven/adminer/adminer/adminer-${_ADMINER_VRN}.php"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/designs/nette/adminer.css" -o "${_D}/$i/o_contrib_seven/adminer/adminer/styles/adminer.css"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/plugin.php" -o "${_D}/$i/o_contrib_seven/adminer/adminer/plugins/plugin.php"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/enum-option.php" -o "${_D}/$i/o_contrib_seven/adminer/adminer/plugins/enum-option.php"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/edit-textarea.php" -o "${_D}/$i/o_contrib_seven/adminer/adminer/plugins/edit-textarea.php"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/version-noverify.php" -o "${_D}/$i/o_contrib_seven/adminer/adminer/plugins/version-noverify.php"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/frames.php" -o "${_D}/$i/o_contrib_seven/adminer/adminer/plugins/frames.php"
       fi
       if [ ! -d "${_D}/$i/o_contrib_seven/advagg" ]; then
         get_dev_contrib "advagg-7.x-2.18.tar.gz"
@@ -1520,6 +1527,13 @@ satellite_download_o_contrib_seven() {
   fi
   get_dev_contrib "admin-7.x-2.0-beta3.tar.gz"
   get_dev_contrib "adminer-7.x-1.1.tar.gz"
+  curl ${crlGet} "https://www.adminer.org/static/download/${_ADMINER_VRN}/adminer-${_ADMINER_VRN}.php" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/adminer-${_ADMINER_VRN}.php"
+  curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/designs/nette/adminer.css" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/styles/adminer.css"
+  curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/plugin.php" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/plugins/plugin.php"
+  curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/enum-option.php" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/plugins/enum-option.php"
+  curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/edit-textarea.php" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/plugins/edit-textarea.php"
+  curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/version-noverify.php" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/plugins/version-noverify.php"
+  curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/plugins/frames.php" -o "${_CORE}/$i/o_contrib_seven/adminer/adminer/plugins/frames.php"
   get_dev_contrib "advagg-7.x-2.18.tar.gz"
   get_dev_contrib "blockcache_alter-7.x-1.x-dev.tar.gz"
   get_dev_contrib "boost-7.x-1.1.tar.gz"

--- a/lib/functions/xtra.sh.inc
+++ b/lib/functions/xtra.sh.inc
@@ -26,8 +26,56 @@ if_install_bzr() {
   fi
 }
 
+if_install_adminer() {
+  if [[ "${_XTRAS_LIST}" =~ "ALL" ]] || [[ "${_XTRAS_LIST}" =~ "ADM" ]]; then
+    _ADMINER_VHOST="${mtrNgx}/vhost.d/chive.${_THIS_FRONT}"
+    if [ ! -d "/var/www/adminer" ] \
+      || [ ! -f "${_ADMINER_VHOST}" ] \
+      || [ ! -f "${pthLog}/adminer-${_ADMINER_VRN}.log" ]; then
+      echo " "
+      if prompt_yes_no "Do you want to install Adminer Manager?" ; then
+        true
+        msg "INFO: Installing Adminer Manager..."
+        cd /var/www
+        rm -rf /var/www/adminer &> /dev/null
+        mkdir adminer
+        cd adminer
+        curl ${crlGet} "https://www.adminer.org/static/download/${_ADMINER_VRN}/adminer-${_ADMINER_VRN}.php" -o "adminer-${_ADMINER_VRN}.php"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/master/designs/nette/adminer.css" -o "adminer.css"
+        ln -s /var/www/adminer/adminer-${_ADMINER_VRN}.php /var/www/adminer/index.php
+        validate_public_ip &> /dev/null
+        validate_xtras_ip &> /dev/null
+        cp -af ${locCnf}/nginx_sql_adminer.conf ${_ADMINER_VHOST}
+        sed -i "s/127.0.0.1:80/${_XTRAS_THISHTIP}:80/g"   ${_ADMINER_VHOST}
+        wait
+        sed -i "s/127.0.0.1:443/${_XTRAS_THISHTIP}:443/g" ${_ADMINER_VHOST}
+        wait
+        sed -i "s/adminer_name/adminer.${_THIS_FRONT}/g"   ${_ADMINER_VHOST}
+        wait
+        touch ${pthLog}/adminer-${_ADMINER_VRN}.log
+        msg "INFO: Adminer Manager installed"
+      else
+        msg "INFO: Adminer Manager installation skipped"
+      fi
+    fi
+  fi
+  if [ -d "/var/www/adminer" ]; then
+    if [ ! -z "${_PHP_CN}" ]; then
+      if [ "${_DEBUG_MODE}" = "YES" ]; then
+        msg "INFO: _PHP_CN set to ${_PHP_CN} for Adminer Manager"
+      fi
+      chown -R ${_PHP_CN}:www-data /var/www/adminer
+    else
+      msg "NOTE: _PHP_CN not set for Chive Manager"
+      chown -R www-data:www-data /var/www/adminer
+    fi
+    find /var/www/adminer -type d -exec chmod 0775 {} \; &> /dev/null
+    find /var/www/adminer -type f -exec chmod 0664 {} \; &> /dev/null
+  fi
+}
+
 if_install_chive() {
-  if [[ "${_XTRAS_LIST}" =~ "ALL" ]] || [[ "${_XTRAS_LIST}" =~ "CHV" ]]; then
+  if [[ "${_XTRAS_LIST}" =~ "CHV" ]]; then
     _CHIVE_VHOST="${mtrNgx}/vhost.d/chive.${_THIS_FRONT}"
     if [ ! -d "/var/www/chive" ] \
       || [ ! -f "${_CHIVE_VHOST}" ] \

--- a/lib/functions/xtra.sh.inc
+++ b/lib/functions/xtra.sh.inc
@@ -41,7 +41,7 @@ if_install_adminer() {
         mkdir adminer
         cd adminer
         curl ${crlGet} "https://www.adminer.org/static/download/${_ADMINER_VRN}/adminer-${_ADMINER_VRN}.php" -o "adminer-${_ADMINER_VRN}.php"
-        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/master/designs/nette/adminer.css" -o "adminer.css"
+        curl ${crlGet} "https://raw.githubusercontent.com/vrana/adminer/v${_ADMINER_VRN}/designs/nette/adminer.css" -o "adminer.css"
         ln -s /var/www/adminer/adminer-${_ADMINER_VRN}.php /var/www/adminer/index.php
         validate_public_ip &> /dev/null
         validate_xtras_ip &> /dev/null


### PR DESCRIPTION
- Use Adminer with Nette theme as the default database manager instead of Chive
- Leaves Chive and SQL Buddy options available
- Adds [adminer](https://www.drupal.org/project/adminer) module to `o_contrib_seven` (this portion won't work until the module is added to @omega8cc repo for `get_dev_contrib`)

Addresses #983