### PR TITLE
Make boost cache clearing configurable.

### DIFF
--- a/aegir/tools/system/daily.sh
+++ b/aegir/tools/system/daily.sh
@@ -360,6 +360,21 @@ enable_modules() {
   done
 }
 
+fix_boost_cache() {
+  if [ -e "${Plr}/cache" ]; then
+    rm -rf ${Plr}/cache/*
+    rm -f ${Plr}/cache/{.boost,.htaccess}
+  else
+    if [ -e "${Plr}/sites/all/drush/drushrc.php" ]; then
+      mkdir -p ${Plr}/cache
+    fi
+  fi
+  if [ -e "${Plr}/cache" ]; then
+    chown ${_HM_U}:www-data ${Plr}/cache &> /dev/null
+    chmod 02775 ${Plr}/cache &> /dev/null
+  fi
+}
+
 fix_user_register_protection() {
 
   if [ -e "${User}/static/control/enable_user_register_protection.info" ] \
@@ -2704,7 +2719,9 @@ process() {
               check_update_le_ssl
               ;;
             esac
-            fix_boost_cache
+            if [ "${_CLEAR_BOOST}" = "DAILY" ]; then
+              fix_boost_cache
+            fi
             fix_site_control_files
             fix_user_register_protection
           fi
@@ -3258,6 +3275,9 @@ else
   fi
   if [ -z "${_MODULES_FIX}" ]; then
     _MODULES_FIX=YES
+  fi
+  if [ -z "${_CLEAR_BOOST}" ]; then
+    _CLEAR_BOOST=DAILY
   fi
   if [ -e "/data/all" ]; then
     find /data/all -type f -name "*.info" -print0 | xargs -0 sed -i \

--- a/aegir/tools/system/daily.sh
+++ b/aegir/tools/system/daily.sh
@@ -360,21 +360,6 @@ enable_modules() {
   done
 }
 
-fix_boost_cache() {
-  if [ -e "${Plr}/cache" ]; then
-    rm -rf ${Plr}/cache/*
-    rm -f ${Plr}/cache/{.boost,.htaccess}
-  else
-    if [ -e "${Plr}/sites/all/drush/drushrc.php" ]; then
-      mkdir -p ${Plr}/cache
-    fi
-  fi
-  if [ -e "${Plr}/cache" ]; then
-    chown ${_HM_U}:www-data ${Plr}/cache &> /dev/null
-    chmod 02775 ${Plr}/cache &> /dev/null
-  fi
-}
-
 fix_user_register_protection() {
 
   if [ -e "${User}/static/control/enable_user_register_protection.info" ] \
@@ -2719,7 +2704,7 @@ process() {
               check_update_le_ssl
               ;;
             esac
-            if [ "${_CLEAR_BOOST}" = "DAILY" ]; then
+            if [ "${_CLEAR_BOOST}" = "YES" ]; then
               fix_boost_cache
             fi
             fix_site_control_files
@@ -3277,7 +3262,7 @@ else
     _MODULES_FIX=YES
   fi
   if [ -z "${_CLEAR_BOOST}" ]; then
-    _CLEAR_BOOST=DAILY
+    _CLEAR_BOOST=YES
   fi
   if [ -e "/data/all" ]; then
     find /data/all -type f -name "*.info" -print0 | xargs -0 sed -i \

--- a/aegir/tools/system/weekly.sh
+++ b/aegir/tools/system/weekly.sh
@@ -374,9 +374,6 @@ count() {
         | sed "s/[\,']//g" 2>&1)
       detect_vanilla_core
       fix_clear_cache
-      if [ "${_CLEAR_BOOST}" = "WEEKLY" ]; then
-        fix_boost_cache
-      fi
       #echo Dir is ${Dir}
       if [ -e "${Dir}/drushrc.php" ] \
         && [ -e "${Dir}/files" ] \

--- a/aegir/tools/system/weekly.sh
+++ b/aegir/tools/system/weekly.sh
@@ -374,6 +374,9 @@ count() {
         | sed "s/[\,']//g" 2>&1)
       detect_vanilla_core
       fix_clear_cache
+      if [ "${_CLEAR_BOOST}" = "WEEKLY" ]; then
+        fix_boost_cache
+      fi
       #echo Dir is ${Dir}
       if [ -e "${Dir}/drushrc.php" ] \
         && [ -e "${Dir}/files" ] \

--- a/lib/settings/barracuda.sh.cnf
+++ b/lib/settings/barracuda.sh.cnf
@@ -735,19 +735,14 @@ _MODULES_SKIP=""
 ###
 ### Control if and how often the boost caches
 ### are clear. By default they are cleared
-### daily.
+### daily. Change to NO if you prefer to 
+### never clear the boost cache files.
 ###
-### Supported options:
-###
-### _CLEAR_BOOST="DAILY"
-### _CLEAR_BOOST="WEEKLY"
-### _CLEAR_BOOST="NEVER"
-###
-### If you choose NEVER make sure that boost cron
+### If you choose NO make sure that boost cron
 ### and/or expire module are removing the boost
 ### caches when needed.
 ###
-_CLEAR_BOOST="DAILY"
+_CLEAR_BOOST="YES"
 
 
 ###

--- a/lib/settings/barracuda.sh.cnf
+++ b/lib/settings/barracuda.sh.cnf
@@ -733,6 +733,24 @@ _MODULES_FIX=YES
 _MODULES_SKIP=""
 
 ###
+### Control if and how often the boost caches
+### are clear. By default they are cleared
+### daily.
+###
+### Supported options:
+###
+### _CLEAR_BOOST="DAILY"
+### _CLEAR_BOOST="WEEKLY"
+### _CLEAR_BOOST="NEVER"
+###
+### If you choose NEVER make sure that boost cron
+### and/or expire module are removing the boost
+### caches when needed.
+###
+_CLEAR_BOOST="DAILY"
+
+
+###
 ### Use YES only if both "randpass 32 esc"
 ### and "randpass 32 alnum" commands produce
 ### well looking, strong passwords and not

--- a/lib/settings/barracuda.sh.cnf
+++ b/lib/settings/barracuda.sh.cnf
@@ -733,10 +733,10 @@ _MODULES_FIX=YES
 _MODULES_SKIP=""
 
 ###
-### Control if and how often the boost caches
-### are clear. By default they are cleared
-### daily. Change to NO if you prefer to 
-### never clear the boost cache files.
+### Control if boost caches should be deleted
+### by BOA. By default they are cleared daily. 
+### Change to NO if you prefer to never clear 
+### the boost cache files.
 ###
 ### If you choose NO make sure that boost cron
 ### and/or expire module are removing the boost


### PR DESCRIPTION
@omega8cc 

here is an attempt PR for  #1115 

I am not sure how to test this.

i think the daily.sh part should work but the positioning of logic in the weekly.sh could e completely off

for me personally a YES, NO option, in the daily.sh would be enough

===

in my use case the project is fully responsive and multi-device caches are not needed

they have been disabled by symlinking all mobile-* folders to normal

on the contrary caches are "expensive" and mobile caches were costly in terms of both CPU and storage

hit ratio was also poorer

but for users that might turn boost cache clear off and also need multi-device supported caches I don't think boost_cron will clear them

they would need to install boost_mobile or implement a similar hook_cron and hook_flush_caches

also a custom expire hook may be needed 