### PR TITLE
o_contrib_eight stable modules - advagg, cdn, robotstxt

### DIFF
--- a/aegir/conf/global.inc
+++ b/aegir/conf/global.inc
@@ -696,6 +696,22 @@ if (!$is_dev) {
         $conf['preprocess_js'] = 1;
       }
     }
+    elseif ($drupal_eight) {
+      if (is_readable('modules/o_contrib_eight/advagg/advagg_bundler/advagg_bundler.module') ||
+          is_readable('modules/advagg/advagg_bundler/advagg_bundler.module') ||
+          is_readable('sites/all/modules/advagg/advagg_bundler/advagg_bundler.module')) {
+        $config['advagg.settings']['css']['combine_media'] = false;
+        $config['advagg.settings']['css']['ie']['limit_selectors'] = true;
+        $config['advagg.settings']['cache_level'] = 3;
+        $config['advagg.settings']['core_groups'] = false;
+        $config['advagg.settings']['enabled'] = true;
+        $config['advagg_bundler.settings']['active'] = true;
+        $config['advagg_css_minify.settings']['minifier'] = 2;
+        $config['advagg_js_minify.settings']['minifier'] = 3;
+        $config['system.performance']['css']['preprocess'] = true;
+        $config['system.performance']['js']['preprocess'] = true;
+      }
+    }
 
     if ($drupal_six || $drupal_seven) {
       if (is_readable('modules/o_contrib/httprl/httprl.module') ||

--- a/aegir/tools/system/daily.sh
+++ b/aegir/tools/system/daily.sh
@@ -1414,7 +1414,8 @@ fix_modules() {
   _AUTO_CONFIG_ADVAGG=NO
   if [ -e "${Plr}/sites/all/modules/advagg" ] \
     || [ -e "${Plr}/modules/o_contrib/advagg" ] \
-    || [ -e "${Plr}/modules/o_contrib_seven/advagg" ]; then
+    || [ -e "${Plr}/modules/o_contrib_seven/advagg" ] \
+    || [ -e "${Plr}/modules/o_contrib_eight/advagg" ]; then
     _MODULE_T=$(run_drush8_nosilent_cmd "pml --status=enabled \
       --type=module | grep \(advagg\)" 2>&1)
     if [[ "${_MODULE_T}" =~ "(advagg)" ]]; then
@@ -3197,7 +3198,7 @@ if [ "${_VMFAMILY}" = "VS" ]; then
 fi
 #
 if [ "${_DOW}" = "7" ]; then
-  _MODULES_ON_EIGHT=
+  _MODULES_ON_EIGHT="robotstxt"
   _MODULES_ON_SEVEN="robotstxt"
   _MODULES_ON_SIX="path_alias_cache robotstxt"
   _MODULES_OFF_EIGHT="automated_cron dblog syslog simpletest update"
@@ -3211,7 +3212,7 @@ if [ "${_DOW}" = "7" ]; then
     stage_file_proxy supercron syslog ultimate_cron update varnish \
     watchdog_live xhprof"
 else
-  _MODULES_ON_EIGHT=
+  _MODULES_ON_EIGHT="robotstxt"
   _MODULES_ON_SEVEN="robotstxt"
   _MODULES_ON_SIX="path_alias_cache robotstxt"
   _MODULES_OFF_EIGHT="dblog syslog update"

--- a/docs/MODULES.txt
+++ b/docs/MODULES.txt
@@ -56,49 +56,49 @@ Contrib [S]upported:
 
 Contrib [S]upported and [B]undled:
 
- adminer -------------------- [D7] ------ [S] [B]
- advagg --------------------- [D6,D7] --- [S] [B]
- blockcache_alter ----------- [D6,D7] --- [S] [B]
- boost ---------------------- [D6,D7] --- [S] [B]
- cdn ------------------------ [D6,D7] --- [S] [B]
- config_perms --------------- [D6,D7] --- [S] [B]
- css_emimage ---------------- [D6,D7] --- [S] [B]
- dbtuner -------------------- [D6] ------ [S] [B]
- display_cache -------------- [D7] ------ [S] [B]
- esi ------------------------ [D6,D7] --- [S] [B]
- expire --------------------- [D6,D7] --- [S] [B]
- filefield_nginx_progress --- [D6,D7] --- [S] [B]
- flood_control -------------- [D7] ------ [S] [B]
- force_password_change ------ [D6,D7] --- [S] [B]
- fpa ------------------------ [D6,D7] --- [S] [B]
- httprl --------------------- [D6,D7] --- [S] [B]
- js ------------------------- [D6,D7] --- [S] [B]
- login_security ------------- [D6,D7] --- [S] [B]
- mydropwizard --------------- [D6] ------ [S] [B]
- nocurrent_pass ------------- [D7] ------ [S] [B]
- panels_content_cache ------- [D6,D7] --- [S] [B]
- phpass --------------------- [D6] ------ [S] [B]
- print ---------------------- [D6,D7] --- [S] [B]
- private_upload ------------- [D6] ------ [S] [B]
- purge ---------------------- [D6,D7] --- [S] [B]
- readonlymode --------------- [D6,D7] --- [S] [B]
- reroute_email -------------- [D6,D7] --- [S] [B]
- securesite ----------------- [D6,D7] --- [S] [B]
- session_expire ------------- [D6,D7] --- [S] [B]
- site_verify ---------------- [D6,D7] --- [S] [B]
- speedy --------------------- [D7] ------ [S] [B]
- taxonomy_edge -------------- [D6,D7] --- [S] [B]
- variable_clean ------------- [D6,D7] --- [S] [B]
- vars ----------------------- [D7] ------ [S] [B]
- views_accelerator ---------- [D7] ------ [S] [B]
- views_cache_bully ---------- [D6,D7] --- [S] [B]
- views_content_cache -------- [D6,D7] --- [S] [B]
- views404 ------------------- [D6,D7] --- [S] [B]
+ adminer -------------------- [D7] --------- [S] [B]
+ advagg --------------------- [D6,D7,D8] --- [S] [B]
+ blockcache_alter ----------- [D6,D7] ------ [S] [B]
+ boost ---------------------- [D6,D7] ------ [S] [B]
+ cdn ------------------------ [D6,D7,D8] --- [S] [B]
+ config_perms --------------- [D6,D7] ------ [S] [B]
+ css_emimage ---------------- [D6,D7] ------ [S] [B]
+ dbtuner -------------------- [D6] --------- [S] [B]
+ display_cache -------------- [D7] --------- [S] [B]
+ esi ------------------------ [D6,D7] ------ [S] [B]
+ expire --------------------- [D6,D7] ------ [S] [B]
+ filefield_nginx_progress --- [D6,D7] ------ [S] [B]
+ flood_control -------------- [D7] --------- [S] [B]
+ force_password_change ------ [D6,D7] ------ [S] [B]
+ fpa ------------------------ [D6,D7] ------ [S] [B]
+ httprl --------------------- [D6,D7] ------ [S] [B]
+ js ------------------------- [D6,D7] ------ [S] [B]
+ login_security ------------- [D6,D7] ------ [S] [B]
+ mydropwizard --------------- [D6] --------- [S] [B]
+ nocurrent_pass ------------- [D7] --------- [S] [B]
+ panels_content_cache ------- [D6,D7] ------ [S] [B]
+ phpass --------------------- [D6] --------- [S] [B]
+ print ---------------------- [D6,D7] ------ [S] [B]
+ private_upload ------------- [D6] --------- [S] [B]
+ purge ---------------------- [D6,D7] ------ [S] [B]
+ readonlymode --------------- [D6,D7] ------ [S] [B]
+ reroute_email -------------- [D6,D7] ------ [S] [B]
+ securesite ----------------- [D6,D7] ------ [S] [B]
+ session_expire ------------- [D6,D7] ------ [S] [B]
+ site_verify ---------------- [D6,D7] ------ [S] [B]
+ speedy --------------------- [D7] --------- [S] [B]
+ taxonomy_edge -------------- [D6,D7] ------ [S] [B]
+ variable_clean ------------- [D6,D7] ------ [S] [B]
+ vars ----------------------- [D7] --------- [S] [B]
+ views_accelerator ---------- [D7] --------- [S] [B]
+ views_cache_bully ---------- [D6,D7] ------ [S] [B]
+ views_content_cache -------- [D6,D7] ------ [S] [B]
+ views404 ------------------- [D6,D7] ------ [S] [B]
 
 Contrib [F]orce[E]nabled
 
- entitycache ---------------- [D7] ------ [S] [B] [FE] unless entitycache_dont_enable = TRUE
- robotstxt ------------------ [D6,D7] --- [S] [B] [FE] static file is generated in sites/foo.com/files/robots.txt
+ entitycache ---------------- [D7] --------- [S] [B] [FE] unless entitycache_dont_enable = TRUE
+ robotstxt ------------------ [D6,D7,D8] --- [S] [B] [FE] static file is generated in sites/foo.com/files/robots.txt
 
 Contrib [F]orce[D]isabled
 
@@ -126,8 +126,8 @@ Contrib [F]orce[D]isabled
 
 Contrib [NA]:
 
- cache_backport ------------- [D6] ------ [S] [B] [NA]
- redis ---------------------- [D6,D7] --- [S] [B] [NA]
+ cache_backport ------------- [D6] --------- [S] [B] [NA]
+ redis ---------------------- [D6,D7,D8] --- [S] [B] [NA]
 
 Contrib [S]oft[E]nabled:
 
@@ -141,9 +141,9 @@ Core [F]orce[E]nabled:
 Core [F]orce[D]isabled:
 
  cookie_cache_bypass -------- [D6] -------------- [FD]
- dblog ---------------------- [D6,D7] ----------- [FD]
- syslog --------------------- [D6,D7] ----------- [FD]
- update --------------------- [D6,D7] ----------- [FD]
+ dblog ---------------------- [D6,D7,D8] -------- [FD]
+ syslog --------------------- [D6,D7,D8] -------- [FD]
+ update --------------------- [D6,D7,D8] -------- [FD]
 
 Drush [E]xtensions [M]aster [S]atellite:
 

--- a/lib/functions/satellite.sh.inc
+++ b/lib/functions/satellite.sh.inc
@@ -1595,6 +1595,9 @@ satellite_download_o_contrib_eight() {
   if [ "${_DEBUG_MODE}" = "YES" ]; then
     msg "${_STATUS} A: Downloading o_contrib_eight modules..."
   fi
+  get_dev_contrib "advagg-8.x-2.0.tar.gz"
+  get_dev_contrib "cdn-8.x-3.0.tar.gz"
+  get_dev_contrib "robotstxt-8.x-1.0.tar.gz"
   if [ ! -e "${_D}/000/modules/redis_eight/${_REDIS_E_VERSION}.info" ]; then
     mkdir -p ${_D}/000/modules
     cd ${_D}/000/modules


### PR DESCRIPTION
For #1096

This pull request provides the advagg, cdn, and robotsxt stable modules via o_contrib_eight. Initial porting of D7 advagg global.inc configuration and daily.sh procedures are included as well.