### PR TITLE
Move excludes first as they are (likely to be) more specific than the…

### DIFF
--- a/aegir/tools/bin/backboa
+++ b/aegir/tools/bin/backboa
@@ -414,7 +414,7 @@ run_backup() {
     --allow-source-mismatch \
     --full-if-older-than ${_AWS_FLC} \
     --asynchronous-upload ${_AWS_OPX} \
-    ${INCLUDE} ${EXCLUDE} ${USER_INCLUDE} ${USER_EXCLUDE} --exclude '**' / ${TARGET} >> ${LOGFILE}
+    ${EXCLUDE} ${USER_EXCLUDE} ${INCLUDE} ${USER_INCLUDE} --exclude '**' / ${TARGET} >> ${LOGFILE}
 }
 
 remove_older_than() {


### PR DESCRIPTION
I think the previously existing EXCLUDE needs to come before the INCLUDE as it is more specific

Also any user specified excludes (USER_EXCLUDE) as proposed in this issue are likely to be more specific than the general include rule, otherwise why exclude something that is not included in the first place.

Regarding the user specified includes I am not sure where they should best be. At the end seems to be more appropriate.