### PR TITLE
update boa info [more] for current years

### DIFF
--- a/aegir/tools/bin/boa
+++ b/aegir/tools/bin/boa
@@ -1579,9 +1579,9 @@ display_info() {
     echo
     if [ -e "/var/log/barracuda_log.txt" ]; then
       if [ "${kind}" = "more" ]; then
-        cat /var/log/barracuda_log.txt | grep 2017
+        cat /var/log/barracuda_log.txt | grep 2015
       fi
-      cat /var/log/barracuda_log.txt | grep 2018
+      cat /var/log/barracuda_log.txt | grep 2016
     fi
     echo
     echo "Please link this information in your submission,"

--- a/aegir/tools/bin/boa
+++ b/aegir/tools/bin/boa
@@ -1579,9 +1579,9 @@ display_info() {
     echo
     if [ -e "/var/log/barracuda_log.txt" ]; then
       if [ "${kind}" = "more" ]; then
-        cat /var/log/barracuda_log.txt | grep 2015
+        cat /var/log/barracuda_log.txt | grep 2017
       fi
-      cat /var/log/barracuda_log.txt | grep 2016
+      cat /var/log/barracuda_log.txt | grep 2018
     fi
     echo
     echo "Please link this information in your submission,"

--- a/aegir/tools/bin/boa
+++ b/aegir/tools/bin/boa
@@ -1579,9 +1579,9 @@ display_info() {
     echo
     if [ -e "/var/log/barracuda_log.txt" ]; then
       if [ "${kind}" = "more" ]; then
-        cat /var/log/barracuda_log.txt | grep 2015
+        cat /var/log/barracuda_log.txt | grep $(date +'%Y' -d 'last year')
       fi
-      cat /var/log/barracuda_log.txt | grep 2016
+      cat /var/log/barracuda_log.txt | grep $(date +%Y)
     fi
     echo
     echo "Please link this information in your submission,"


### PR DESCRIPTION
The current `boa info` and `boa info more` commands restrict data to 2016 and 2015, respectively. This is a minor change to pull in 2018 and 2017 entries instead.