### PR TITLE
advagg-8.x-3.4 and cdn-8.x-3.2 updates

### DIFF
--- a/lib/functions/satellite.sh.inc
+++ b/lib/functions/satellite.sh.inc
@@ -1590,8 +1590,8 @@ satellite_download_o_contrib_eight() {
   if [ "${_DEBUG_MODE}" = "YES" ]; then
     msg "${_STATUS} A: Downloading o_contrib_eight modules..."
   fi
-  get_dev_contrib "advagg-8.x-3.2.tar.gz"
-  get_dev_contrib "cdn-8.x-3.1.tar.gz"
+  get_dev_contrib "advagg-8.x-3.4.tar.gz"
+  get_dev_contrib "cdn-8.x-3.2.tar.gz"
   get_dev_contrib "robotstxt-8.x-1.1.tar.gz"
   if [ ! -e "${_D}/000/modules/redis_eight/${_REDIS_E_VERSION}.info" ]; then
     mkdir -p ${_D}/000/modules


### PR DESCRIPTION
This is a request to update o_eight_contrib modules. It looks like the got missed in BOA 3.2.2