### PR TITLE
typo fix for an elif statement

### DIFF
--- a/lib/functions/php.sh.inc
+++ b/lib/functions/php.sh.inc
@@ -750,7 +750,7 @@ update_php_extensions() {
     mrun "make --quiet" 2> /dev/null
     mrun "make --quiet install" 2> /dev/null
     touch ${pthLog}/php-pecl-jsmin-${_JSMIN_VRN}-${_T_PHP_VRN}.log
-  else [ ! -e "${pthLog}/php-pecl-jsmin-${_JSMIN_LEGACY_VRN}-${_T_PHP_VRN}.log" ]; then
+  elif [ ! -e "${pthLog}/php-pecl-jsmin-${_JSMIN_LEGACY_VRN}-${_T_PHP_VRN}.log" ]; then
     msg "INFO: Installing JSMin for PHP ${_T_PHP_VRN}..."
     cd /var/opt
     rm -rf pecl-jsmin*


### PR DESCRIPTION
I think that as there is a condition, the statement should be `elif`, now if `else` is desired as a default then the condition and `then` should be removed.

I made the commit changing to an `elif`

This is the error: 

```
~# barracuda up-head
/opt/tmp/boa/lib/functions/php.sh.inc: line 753: syntax error near unexpected token `then'
/opt/tmp/boa/lib/functions/php.sh.inc: line 753: `  else [ ! -e "${pthLog}/php-pecl-jsmin-${_JSMIN_LEGACY_VRN}-${_T_PHP_VRN}.log" ]; then'

```