### PR TITLE
Replace Google DNS servers for Cloudflare DNS servers

### DIFF
--- a/BOA.sh.txt
+++ b/BOA.sh.txt
@@ -86,8 +86,8 @@ fix_dns_settings() {
     fi
   fi
   if [ ! -e "${vBs}/resolv.conf.tmp" ]; then
-    echo "nameserver 8.8.8.8" >${vBs}/resolv.conf.tmp
-    echo "nameserver 8.8.4.4" >>${vBs}/resolv.conf.tmp
+    echo "nameserver 1.1.1.1" >${vBs}/resolv.conf.tmp
+    echo "nameserver 1.0.0.1" >>${vBs}/resolv.conf.tmp
   fi
   if [ ! -e "${vBs}/resolv.conf.vanilla" ]; then
     for Pre in `ls -la ${vBs}/resolv.conf.pre-*`; do
@@ -125,19 +125,19 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_X=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_X}" ]; then
-        echo "        label = \"google-servers\";" > ${dnsLi}
-        echo "        ip=8.8.8.8;" >> ${dnsLi}
-        echo "        ip=8.8.4.4;" >> ${dnsLi}
+        echo "        label = \"cloudflare-servers\";" > ${dnsLi}
+        echo "        ip=1.1.1.1;" >> ${dnsLi}
+        echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
     fi
-    _CUSTOM_DNS_TEST=$(grep 8.8.8.8 /etc/pdnsd.conf 2>&1)
+    _CUSTOM_DNS_TEST=$(grep 1.1.1.1 /etc/pdnsd.conf 2>&1)
     _BROKEN_DNS_CONF=$(grep "ip=Dynamic" /etc/pdnsd.conf 2>&1)
-    if [[ "${_CUSTOM_DNS_TEST}" =~ "8.8.8.8" ]] \
+    if [[ "${_CUSTOM_DNS_TEST}" =~ "1.1.1.1" ]] \
       || [ ! -e "${dnsLi}" ] \
       || [ -e "/root/.use.default.nameservers.cnf" ] \
       || [ -e "/root/.use.local.nameservers.cnf" ] \
       || [[ "${_BROKEN_DNS_CONF}" =~ "Dynamic" ]]; then
-      echo "        label = \"google-servers\";" > ${dnsLi}
+      echo "        label = \"cloudflare-servers\";" > ${dnsLi}
       for _IP in `cat /etc/resolv.conf \
         | sed 's/.*127.0.0.1.*//g; s/.*search.*//g; s/.*Dynamic.*//g' \
         | cut -d ' ' -f2 \
@@ -152,15 +152,15 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_Y=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_Y}" ]; then
-         echo "        ip=8.8.8.8;" >> ${dnsLi}
-         echo "        ip=8.8.4.4;" >> ${dnsLi}
+         echo "        ip=1.1.1.1;" >> ${dnsLi}
+         echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
       ### echo debug dns A
-      _DNS_TPL_TEST=$(grep "google-servers" /etc/pdnsd.conf 2>&1)
-      _DNS_RGX_TEST=$(grep "google-servers" /root/.local.dns.IP.list 2>&1)
-      if [[ "${_DNS_TPL_TEST}" =~ "google-servers" ]] \
-        && [[ "${_DNS_RGX_TEST}" =~ "google-servers" ]]; then
-        sed -i '/        label = \"google-servers\";/ {r /root/.local.dns.IP.list
+      _DNS_TPL_TEST=$(grep "cloudflare-servers" /etc/pdnsd.conf 2>&1)
+      _DNS_RGX_TEST=$(grep "cloudflare-servers" /root/.local.dns.IP.list 2>&1)
+      if [[ "${_DNS_TPL_TEST}" =~ "cloudflare-servers" ]] \
+        && [[ "${_DNS_RGX_TEST}" =~ "cloudflare-servers" ]]; then
+        sed -i '/        label = \"cloudflare-servers\";/ {r /root/.local.dns.IP.list
 d;};' /etc/pdnsd.conf
         wait
       fi
@@ -179,7 +179,7 @@ check_dns_settings() {
   if [ -e "/root/.use.local.nameservers.cnf" ]; then
     _USE_PROVIDER_DNS=YES
   else
-    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 8.8.8.8 -w 10 2>&1)
+    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 1.1.1.1 -w 10 2>&1)
   fi
   if [[ "${_REMOTE_DNS_TEST}" =~ "no servers could be reached" ]] \
     || [ "${_USE_DEFAULT_DNS}" = "YES" ] \
@@ -1275,8 +1275,8 @@ update_wrappers() {
     if [ -e "${vBs}/resolv.conf.vanilla" ]; then
       cat ${vBs}/resolv.conf.vanilla >/etc/resolv.conf
     fi
-    echo "nameserver 8.8.8.8" >>/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >>/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
     check_dns_settings
   else
     check_dns_settings
@@ -1418,8 +1418,8 @@ setup() {
     if [ -e "${vBs}/resolv.conf.vanilla" ]; then
       cat ${vBs}/resolv.conf.vanilla >/etc/resolv.conf
     fi
-    echo "nameserver 8.8.8.8" >>/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >>/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
     check_dns_settings
   else
     check_dns_settings

--- a/aegir/conf/pdnsd.conf
+++ b/aegir/conf/pdnsd.conf
@@ -27,9 +27,9 @@ global {
 #  Specify the IP address of the real DNS server to query against here:
 #
 server {
-        label = "google-servers";
-        ip=8.8.8.8;
-        ip=8.8.4.4;
+        label = "cloudflare-servers";
+        ip=1.1.1.1;
+        ip=1.0.0.1;
         timeout=100;      // By default 50.
         interval=5m;      // Test every 5 minutes.
         uptest=ping;

--- a/aegir/tools/bin/barracuda
+++ b/aegir/tools/bin/barracuda
@@ -128,8 +128,8 @@ fix_dns_settings() {
     fi
   fi
   if [ ! -e "${vBs}/resolv.conf.tmp" ]; then
-    echo "nameserver 8.8.8.8" >${vBs}/resolv.conf.tmp
-    echo "nameserver 8.8.4.4" >>${vBs}/resolv.conf.tmp
+    echo "nameserver 1.1.1.1" >${vBs}/resolv.conf.tmp
+    echo "nameserver 1.0.0.1" >>${vBs}/resolv.conf.tmp
   fi
   if [ ! -e "${vBs}/resolv.conf.vanilla" ]; then
     for Pre in `ls -la ${vBs}/resolv.conf.pre-*`; do
@@ -167,18 +167,18 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_X=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_X}" ]; then
-        echo "        label = \"google-servers\";" > ${dnsLi}
-        echo "        ip=8.8.8.8;" >> ${dnsLi}
-        echo "        ip=8.8.4.4;" >> ${dnsLi}
+        echo "        label = \"cloudflare-servers\";" > ${dnsLi}
+        echo "        ip=1.1.1.1;" >> ${dnsLi}
+        echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
     fi
-    _CUSTOM_DNS_TEST=$(grep 8.8.8.8 /etc/pdnsd.conf 2>&1)
+    _CUSTOM_DNS_TEST=$(grep 1.1.1.1 /etc/pdnsd.conf 2>&1)
     _BROKEN_DNS_CONF=$(grep "ip=Dynamic" /etc/pdnsd.conf 2>&1)
-    if [[ "${_CUSTOM_DNS_TEST}" =~ "8.8.8.8" ]] \
+    if [[ "${_CUSTOM_DNS_TEST}" =~ "1.1.1.1" ]] \
       || [ -e "/root/.use.default.nameservers.cnf" ] \
       || [ -e "/root/.use.local.nameservers.cnf" ] \
       || [[ "${_BROKEN_DNS_CONF}" =~ "Dynamic" ]]; then
-      echo "        label = \"google-servers\";" > ${dnsLi}
+      echo "        label = \"cloudflare-servers\";" > ${dnsLi}
       for _IP in `cat /etc/resolv.conf \
         | sed 's/.*127.0.0.1.*//g; s/.*search.*//g; s/.*Dynamic.*//g' \
         | cut -d ' ' -f2 \
@@ -193,15 +193,15 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_Y=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_Y}" ]; then
-         echo "        ip=8.8.8.8;" >> ${dnsLi}
-         echo "        ip=8.8.4.4;" >> ${dnsLi}
+         echo "        ip=1.1.1.1;" >> ${dnsLi}
+         echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
       ### echo debug dns A
-      _DNS_TPL_TEST=$(grep "google-servers" /etc/pdnsd.conf 2>&1)
-      _DNS_RGX_TEST=$(grep "google-servers" /root/.local.dns.IP.list 2>&1)
-      if [[ "${_DNS_TPL_TEST}" =~ "google-servers" ]] \
-        && [[ "${_DNS_RGX_TEST}" =~ "google-servers" ]]; then
-        sed -i '/        label = \"google-servers\";/ {r /root/.local.dns.IP.list
+      _DNS_TPL_TEST=$(grep "cloudflare-servers" /etc/pdnsd.conf 2>&1)
+      _DNS_RGX_TEST=$(grep "cloudflare-servers" /root/.local.dns.IP.list 2>&1)
+      if [[ "${_DNS_TPL_TEST}" =~ "cloudflare-servers" ]] \
+        && [[ "${_DNS_RGX_TEST}" =~ "cloudflare-servers" ]]; then
+        sed -i '/        label = \"cloudflare-servers\";/ {r /root/.local.dns.IP.list
 d;};' /etc/pdnsd.conf
         wait
       fi
@@ -220,7 +220,7 @@ check_dns_settings() {
   if [ -e "/root/.use.local.nameservers.cnf" ]; then
     _USE_PROVIDER_DNS=YES
   else
-    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 8.8.8.8 -w 10 2>&1)
+    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 1.1.1.1 -w 10 2>&1)
   fi
   if [[ "${_REMOTE_DNS_TEST}" =~ "no servers could be reached" ]] \
     || [ "${_USE_DEFAULT_DNS}" = "YES" ] \
@@ -1009,8 +1009,8 @@ check_dns_curl() {
     if [ -e "${vBs}/resolv.conf.vanilla" ]; then
       cat ${vBs}/resolv.conf.vanilla >/etc/resolv.conf
     fi
-    echo "nameserver 8.8.8.8" >>/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >>/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
     check_dns_settings
   else
     check_dns_settings

--- a/aegir/tools/bin/boa
+++ b/aegir/tools/bin/boa
@@ -281,8 +281,8 @@ fix_dns_settings() {
     fi
   fi
   if [ ! -e "${vBs}/resolv.conf.tmp" ]; then
-    echo "nameserver 8.8.8.8" >${vBs}/resolv.conf.tmp
-    echo "nameserver 8.8.4.4" >>${vBs}/resolv.conf.tmp
+    echo "nameserver 1.1.1.1" >${vBs}/resolv.conf.tmp
+    echo "nameserver 1.0.0.1" >>${vBs}/resolv.conf.tmp
   fi
   if [ ! -e "${vBs}/resolv.conf.vanilla" ]; then
     for Pre in `ls -la ${vBs}/resolv.conf.pre-*`; do
@@ -320,18 +320,18 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_X=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_X}" ]; then
-        echo "        label = \"google-servers\";" > ${dnsLi}
-        echo "        ip=8.8.8.8;" >> ${dnsLi}
-        echo "        ip=8.8.4.4;" >> ${dnsLi}
+        echo "        label = \"cloudflare-servers\";" > ${dnsLi}
+        echo "        ip=1.1.1.1;" >> ${dnsLi}
+        echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
     fi
-    _CUSTOM_DNS_TEST=$(grep 8.8.8.8 /etc/pdnsd.conf 2>&1)
+    _CUSTOM_DNS_TEST=$(grep 1.1.1.1 /etc/pdnsd.conf 2>&1)
     _BROKEN_DNS_CONF=$(grep "ip=Dynamic" /etc/pdnsd.conf 2>&1)
-    if [[ "${_CUSTOM_DNS_TEST}" =~ "8.8.8.8" ]] \
+    if [[ "${_CUSTOM_DNS_TEST}" =~ "1.1.1.1" ]] \
       || [ -e "/root/.use.default.nameservers.cnf" ] \
       || [ -e "/root/.use.local.nameservers.cnf" ] \
       || [[ "${_BROKEN_DNS_CONF}" =~ "Dynamic" ]]; then
-      echo "        label = \"google-servers\";" > ${dnsLi}
+      echo "        label = \"cloudflare-servers\";" > ${dnsLi}
       for _IP in `cat /etc/resolv.conf \
         | sed 's/.*127.0.0.1.*//g; s/.*search.*//g; s/.*Dynamic.*//g' \
         | cut -d ' ' -f2 \
@@ -346,15 +346,15 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_Y=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_Y}" ]; then
-         echo "        ip=8.8.8.8;" >> ${dnsLi}
-         echo "        ip=8.8.4.4;" >> ${dnsLi}
+         echo "        ip=1.1.1.1;" >> ${dnsLi}
+         echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
       ### echo debug dns A
-      _DNS_TPL_TEST=$(grep "google-servers" /etc/pdnsd.conf 2>&1)
-      _DNS_RGX_TEST=$(grep "google-servers" /root/.local.dns.IP.list 2>&1)
-      if [[ "${_DNS_TPL_TEST}" =~ "google-servers" ]] \
-        && [[ "${_DNS_RGX_TEST}" =~ "google-servers" ]]; then
-        sed -i '/        label = \"google-servers\";/ {r /root/.local.dns.IP.list
+      _DNS_TPL_TEST=$(grep "clouflare-servers" /etc/pdnsd.conf 2>&1)
+      _DNS_RGX_TEST=$(grep "cloudflare-servers" /root/.local.dns.IP.list 2>&1)
+      if [[ "${_DNS_TPL_TEST}" =~ "cloudflare-servers" ]] \
+        && [[ "${_DNS_RGX_TEST}" =~ "cloudflare-servers" ]]; then
+        sed -i '/        label = \"cloudflare-servers\";/ {r /root/.local.dns.IP.list
 d;};' /etc/pdnsd.conf
         wait
       fi
@@ -373,7 +373,7 @@ check_dns_settings() {
   if [ -e "/root/.use.local.nameservers.cnf" ]; then
     _USE_PROVIDER_DNS=YES
   else
-    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 8.8.8.8 -w 10 2>&1)
+    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 1.1.1.1 -w 10 2>&1)
   fi
   if [[ "${_REMOTE_DNS_TEST}" =~ "no servers could be reached" ]] \
     || [ "${_USE_DEFAULT_DNS}" = "YES" ] \
@@ -1261,8 +1261,8 @@ check_dns_curl() {
     if [ -e "${vBs}/resolv.conf.vanilla" ]; then
       cat ${vBs}/resolv.conf.vanilla >/etc/resolv.conf
     fi
-    echo "nameserver 8.8.8.8" >>/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >>/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
     check_dns_settings
   else
     check_dns_settings

--- a/aegir/tools/bin/cluster
+++ b/aegir/tools/bin/cluster
@@ -1103,12 +1103,12 @@ upgrade_db_cluster() {
 
 install_host() {
 
-  _CUSTOM_DNS_TEST=$(grep 8.8.8.8 /etc/resolv.conf 2>&1)
-  if [[ ! "${_CUSTOM_DNS_TEST}" =~ "8.8.8.8" ]]; then
+  _CUSTOM_DNS_TEST=$(grep 1.1.1.1 /etc/resolv.conf 2>&1)
+  if [[ ! "${_CUSTOM_DNS_TEST}" =~ "1.1.1.1" ]]; then
     echo "Fixing resolver..."
     cp -af /etc/resolv.conf /etc/resolv.conf.prev
-    echo "nameserver 8.8.8.8" >/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
     cat /etc/resolv.conf.prev >>/etc/resolv.conf
     cat /etc/resolv.conf
     echo

--- a/aegir/tools/bin/octopus
+++ b/aegir/tools/bin/octopus
@@ -71,8 +71,8 @@ fix_dns_settings() {
     fi
   fi
   if [ ! -e "${vBs}/resolv.conf.tmp" ]; then
-    echo "nameserver 8.8.8.8" >${vBs}/resolv.conf.tmp
-    echo "nameserver 8.8.4.4" >>${vBs}/resolv.conf.tmp
+    echo "nameserver 1.1.1.1" >${vBs}/resolv.conf.tmp
+    echo "nameserver 1.0.0.1" >>${vBs}/resolv.conf.tmp
   fi
   if [ ! -e "${vBs}/resolv.conf.vanilla" ]; then
     for Pre in `ls -la ${vBs}/resolv.conf.pre-*`; do
@@ -110,18 +110,18 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_X=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_X}" ]; then
-        echo "        label = \"google-servers\";" > ${dnsLi}
-        echo "        ip=8.8.8.8;" >> ${dnsLi}
-        echo "        ip=8.8.4.4;" >> ${dnsLi}
+        echo "        label = \"cloudflare-servers\";" > ${dnsLi}
+        echo "        ip=1.1.1.1;" >> ${dnsLi}
+        echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
     fi
-    _CUSTOM_DNS_TEST=$(grep 8.8.8.8 /etc/pdnsd.conf 2>&1)
+    _CUSTOM_DNS_TEST=$(grep 1.1.1.1 /etc/pdnsd.conf 2>&1)
     _BROKEN_DNS_CONF=$(grep "ip=Dynamic" /etc/pdnsd.conf 2>&1)
-    if [[ "${_CUSTOM_DNS_TEST}" =~ "8.8.8.8" ]] \
+    if [[ "${_CUSTOM_DNS_TEST}" =~ "1.1.1.1" ]] \
       || [ -e "/root/.use.default.nameservers.cnf" ] \
       || [ -e "/root/.use.local.nameservers.cnf" ] \
       || [[ "${_BROKEN_DNS_CONF}" =~ "Dynamic" ]]; then
-      echo "        label = \"google-servers\";" > ${dnsLi}
+      echo "        label = \"cloudflare-servers\";" > ${dnsLi}
       for _IP in `cat /etc/resolv.conf \
         | sed 's/.*127.0.0.1.*//g; s/.*search.*//g; s/.*Dynamic.*//g' \
         | cut -d ' ' -f2 \
@@ -136,15 +136,15 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_Y=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_Y}" ]; then
-         echo "        ip=8.8.8.8;" >> ${dnsLi}
-         echo "        ip=8.8.4.4;" >> ${dnsLi}
+         echo "        ip=1.1.1.1;" >> ${dnsLi}
+         echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
       ### echo debug dns A
-      _DNS_TPL_TEST=$(grep "google-servers" /etc/pdnsd.conf 2>&1)
-      _DNS_RGX_TEST=$(grep "google-servers" /root/.local.dns.IP.list 2>&1)
-      if [[ "${_DNS_TPL_TEST}" =~ "google-servers" ]] \
-        && [[ "${_DNS_RGX_TEST}" =~ "google-servers" ]]; then
-        sed -i '/        label = \"google-servers\";/ {r /root/.local.dns.IP.list
+      _DNS_TPL_TEST=$(grep "cloudflare-servers" /etc/pdnsd.conf 2>&1)
+      _DNS_RGX_TEST=$(grep "cloudflare-servers" /root/.local.dns.IP.list 2>&1)
+      if [[ "${_DNS_TPL_TEST}" =~ "cloudflare-servers" ]] \
+        && [[ "${_DNS_RGX_TEST}" =~ "cloudflare-servers" ]]; then
+        sed -i '/        label = \"cloudflare-servers\";/ {r /root/.local.dns.IP.list
 d;};' /etc/pdnsd.conf
         wait
       fi
@@ -163,7 +163,7 @@ check_dns_settings() {
   if [ -e "/root/.use.local.nameservers.cnf" ]; then
     _USE_PROVIDER_DNS=YES
   else
-    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 8.8.8.8 -w 10 2>&1)
+    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 1.1.1.1 -w 10 2>&1)
   fi
   if [[ "${_REMOTE_DNS_TEST}" =~ "no servers could be reached" ]] \
     || [ "${_USE_DEFAULT_DNS}" = "YES" ] \
@@ -1052,8 +1052,8 @@ check_dns_curl() {
     if [ -e "${vBs}/resolv.conf.vanilla" ]; then
       cat ${vBs}/resolv.conf.vanilla >/etc/resolv.conf
     fi
-    echo "nameserver 8.8.8.8" >>/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >>/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
     check_dns_settings
   else
     check_dns_settings

--- a/aegir/tools/system/conf/https_proxy_le.conf
+++ b/aegir/tools/system/conf/https_proxy_le.conf
@@ -6,7 +6,7 @@ server {
   server_name                  _;
   ssl_stapling                 on;
   ssl_stapling_verify          on;
-  resolver 8.8.8.8 8.8.4.4 valid=300s;
+  resolver 1.1.1.1 1.0.0.1 valid=300s;
   resolver_timeout             5s;
   ssl_dhparam                  /etc/ssl/private/nginx-wild-ssl.dhp;
   ssl_certificate_key          /data/disk/oct_uid/config/server_master/ssl.d/domain_name/openssl.key;

--- a/aegir/tools/system/conf/ssl_proxy.conf
+++ b/aegir/tools/system/conf/ssl_proxy.conf
@@ -13,7 +13,7 @@ server {
   ssl_prefer_server_ciphers    on;
   ssl_stapling on;
   ssl_stapling_verify on;
-  resolver 8.8.8.8 8.8.4.4 valid=300s;
+  resolver 1.1.1.1 1.0.0.1 valid=300s;
   resolver_timeout 5s;
   keepalive_timeout            70;
   access_log                   off;

--- a/aegir/tools/system/daily.sh
+++ b/aegir/tools/system/daily.sh
@@ -3441,7 +3441,7 @@ else
     wait
     sed -i "s/.*resolver_timeout .*//g" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf           &> /dev/null
     wait
-    sed -i "s/ssl_prefer_server_ciphers .*/ssl_prefer_server_ciphers on;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n  resolver 8.8.8.8 8.8.4.4 valid=300s;\n  resolver_timeout 5s;/g" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf &> /dev/null
+    sed -i "s/ssl_prefer_server_ciphers .*/ssl_prefer_server_ciphers on;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n  resolver 1.1.1.1 1.0.0.1 valid=300s;\n  resolver_timeout 5s;/g" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf &> /dev/null
     wait
     sed -i "s/ *$//g; /^$/d" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf                      &> /dev/null
     wait

--- a/aegir/tools/system/manage_ltd_users.sh
+++ b/aegir/tools/system/manage_ltd_users.sh
@@ -2050,7 +2050,7 @@ else
   _THISHTIP=$(echo $(getent ahostsv4 ${_THISHTNM}) \
     | cut -d: -f2 \
     | awk '{ print $1}' 2>&1)
-  sed -i "s/8.8.8.8/${_THISHTIP}/g" ${_THIS_LTD_CONF}
+  sed -i "s/1.1.1.1/${_THISHTIP}/g" ${_THIS_LTD_CONF}
   wait
   if [ ! -e "/root/.allow.mc.cnf" ]; then
     sed -i "s/'mc', //g" ${_THIS_LTD_CONF}

--- a/docs/ctrl/system.ctrl
+++ b/docs/ctrl/system.ctrl
@@ -83,7 +83,7 @@ by the BOA install and upgrade tools exclusively.
 
   This file, if exists, allows to use original (or custom) nameservers
   provided on the system install by your hosting provider. It will automatically
-  configure pdnsd server to use these IPs instead of public Google DNS servers.
+  configure pdnsd server to use these IPs instead of public Cloudflare DNS servers.
 
   It depends on existence of another file with custom name servers to use
   listed, one per line: /var/backups/resolv.conf.vanilla -- for example:
@@ -96,7 +96,7 @@ by the BOA install and upgrade tools exclusively.
  @=> /root/.use.default.nameservers.cnf
 
   This file, if exists, allows to revert pdnsd cache server configuration
-  to use Google DNS again (which is BOA default).
+  to use Cloudflare DNS again (which is BOA default).
 
   Note that to restore default DNS cache configuration on barracuda upgrade,
   you must delete the /root/.use.local.nameservers.cnf file, if still exists.

--- a/lib/functions/dns.sh.inc
+++ b/lib/functions/dns.sh.inc
@@ -16,8 +16,8 @@ fix_dns_settings() {
     fi
   fi
   if [ ! -e "${vBs}/resolv.conf.tmp" ]; then
-    echo "nameserver 8.8.8.8" >${vBs}/resolv.conf.tmp
-    echo "nameserver 8.8.4.4" >>${vBs}/resolv.conf.tmp
+    echo "nameserver 1.1.1.1" >${vBs}/resolv.conf.tmp
+    echo "nameserver 1.0.0.1" >>${vBs}/resolv.conf.tmp
   fi
   if [ ! -e "${vBs}/resolv.conf.vanilla" ]; then
     for Pre in `ls -la ${vBs}/resolv.conf.pre-*`; do
@@ -55,18 +55,18 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_X=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_X}" ]; then
-        echo "        label = \"google-servers\";" > ${dnsLi}
-        echo "        ip=8.8.8.8;" >> ${dnsLi}
-        echo "        ip=8.8.4.4;" >> ${dnsLi}
+        echo "        label = \"cloudflare-servers\";" > ${dnsLi}
+        echo "        ip=1.1.1.1;" >> ${dnsLi}
+        echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
     fi
-    _CUSTOM_DNS_TEST=$(grep 8.8.8.8 /etc/pdnsd.conf 2>&1)
+    _CUSTOM_DNS_TEST=$(grep 1.1.1.1 /etc/pdnsd.conf 2>&1)
     _BROKEN_DNS_CONF=$(grep "ip=Dynamic" /etc/pdnsd.conf 2>&1)
-    if [[ "${_CUSTOM_DNS_TEST}" =~ "8.8.8.8" ]] \
+    if [[ "${_CUSTOM_DNS_TEST}" =~ "1.1.1.1" ]] \
       || [ -e "/root/.use.default.nameservers.cnf" ] \
       || [ -e "/root/.use.local.nameservers.cnf" ] \
       || [[ "${_BROKEN_DNS_CONF}" =~ "Dynamic" ]]; then
-      echo "        label = \"google-servers\";" > ${dnsLi}
+      echo "        label = \"cloudflare-servers\";" > ${dnsLi}
       for _IP in `cat /etc/resolv.conf \
         | sed 's/.*127.0.0.1.*//g; s/.*search.*//g; s/.*Dynamic.*//g' \
         | cut -d ' ' -f2 \
@@ -81,15 +81,15 @@ fix_dns_settings() {
       wait
       _BROKEN_DNS_TEST_Y=$(grep "\." ${dnsLi} 2>&1)
       if [ -z "${_BROKEN_DNS_TEST_Y}" ]; then
-         echo "        ip=8.8.8.8;" >> ${dnsLi}
-         echo "        ip=8.8.4.4;" >> ${dnsLi}
+         echo "        ip=1.1.1.1;" >> ${dnsLi}
+         echo "        ip=1.0.0.1;" >> ${dnsLi}
       fi
       ### echo debug dns A
-      _DNS_TPL_TEST=$(grep "google-servers" /etc/pdnsd.conf 2>&1)
-      _DNS_RGX_TEST=$(grep "google-servers" /root/.local.dns.IP.list 2>&1)
-      if [[ "${_DNS_TPL_TEST}" =~ "google-servers" ]] \
-        && [[ "${_DNS_RGX_TEST}" =~ "google-servers" ]]; then
-        sed -i '/        label = \"google-servers\";/ {r /root/.local.dns.IP.list
+      _DNS_TPL_TEST=$(grep "cloudflare-servers" /etc/pdnsd.conf 2>&1)
+      _DNS_RGX_TEST=$(grep "cloudflare-servers" /root/.local.dns.IP.list 2>&1)
+      if [[ "${_DNS_TPL_TEST}" =~ "cloudflare-servers" ]] \
+        && [[ "${_DNS_RGX_TEST}" =~ "cloudflare-servers" ]]; then
+        sed -i '/        label = \"cloudflare-servers\";/ {r /root/.local.dns.IP.list
 d;};' /etc/pdnsd.conf
         wait
       else
@@ -116,7 +116,7 @@ check_dns_settings() {
   if [ -e "/root/.use.local.nameservers.cnf" ]; then
     _USE_PROVIDER_DNS=YES
   else
-    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 8.8.8.8 -w 10 2>&1)
+    _REMOTE_DNS_TEST=$(host -a files.aegir.cc 1.1.1.1 -w 10 2>&1)
   fi
   if [[ "${_REMOTE_DNS_TEST}" =~ "no servers could be reached" ]] \
     || [ "${_USE_DEFAULT_DNS}" = "YES" ] \
@@ -358,8 +358,8 @@ install_pdnsd_cache() {
   cp -af /etc/resolv.conf ${vBs}/resolv.conf.pre-${_X_VERSION}-${_NOW}
   if [ "${_USE_PROVIDER_DNS}" != "YES" ]; then
     rm -f /etc/resolv.conf
-    echo "nameserver 8.8.8.8" > /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    echo "nameserver 1.1.1.1" > /etc/resolv.conf
+    echo "nameserver 1.0.0.1" >> /etc/resolv.conf
   fi
   rm -f /etc/apt/sources.list.d/openssl.list
   st_runner "apt-get update -qq" &> /dev/null
@@ -371,8 +371,8 @@ install_pdnsd_cache() {
   st_runner "aptitude purge resolvconf -y" &> /dev/null
   if [ "${_USE_PROVIDER_DNS}" != "YES" ]; then
     rm -f /etc/resolv.conf
-    echo "nameserver 8.8.8.8" > /etc/resolv.conf
-    echo "nameserver 8.8.4.4" >> /etc/resolv.conf
+    echo "nameserver 1.1.1.1" > /etc/resolv.conf
+    echo "nameserver 1.0.0.1" >> /etc/resolv.conf
   fi
   if [ "${_OSV}" = "stretch" ]; then
     st_runner "${_INSTALL} resolvconf" &> /dev/null
@@ -457,8 +457,8 @@ install_pdnsd_cache() {
       cat ${vBs}/resolv.conf.vanilla >/etc/resolv.conf
     fi
     echo "nameserver 127.0.0.1" >> /etc/resolv.conf
-    echo "nameserver 8.8.8.8" >>/etc/resolv.conf
-    echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+    echo "nameserver 1.1.1.1" >>/etc/resolv.conf
+    echo "nameserver 1.0.0.1" >>/etc/resolv.conf
   fi
   if [ -e "/etc/NetworkManager/NetworkManager.conf" ]; then
     sed -i "s/^dns=.*/dns=pdnsd/g" \

--- a/lib/functions/nginx.sh.inc
+++ b/lib/functions/nginx.sh.inc
@@ -626,7 +626,7 @@ fix_update_nginx_config() {
       wait
       sed -i "s/.*resolver_timeout .*//g" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf           &> /dev/null
       wait
-      sed -i "s/ssl_prefer_server_ciphers .*/ssl_prefer_server_ciphers on;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n  resolver 8.8.8.8 8.8.4.4 valid=300s;\n  resolver_timeout 5s;/g" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf &> /dev/null
+      sed -i "s/ssl_prefer_server_ciphers .*/ssl_prefer_server_ciphers on;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n  resolver 1.1.1.1 1.0.0.1 valid=300s;\n  resolver_timeout 5s;/g" /var/aegir/config/server_*/nginx/pre.d/*ssl_proxy.conf &> /dev/null
       wait
       sed -i "s/ *$//g; /^$/d" /var/aegir/config/server_*/nginx/pre.d/*.conf                               &> /dev/null
       wait

--- a/lib/functions/system.sh.inc
+++ b/lib/functions/system.sh.inc
@@ -3088,8 +3088,8 @@ if_jessie_to_stretch() {
         mv -f /etc/resolv.conf /etc/resolv.conf.pre-dist-upgrade
       fi
       rm -f /etc/resolv.conf
-      echo "nameserver 8.8.8.8" >/etc/resolv.conf
-      echo "nameserver 8.8.4.4" >>/etc/resolv.conf
+      echo "nameserver 1.1.1.1" >/etc/resolv.conf
+      echo "nameserver 1.0.0.1" >>/etc/resolv.conf
       if [ -e "/etc/resolv.conf.pre-dist-upgrade" ]; then
         cat /etc/resolv.conf.pre-dist-upgrade >>/etc/resolv.conf
       fi


### PR DESCRIPTION
This suggest to use Cloudflare DNS servers by default instead of Google servers. This will gain DNS performance as many tests have shown that generally speaking for any region, Cloudflare DNS are faster.

Take a look at:

https://medium.com/@nykolas.z/dns-resolvers-performance-compared-cloudflare-x-google-x-quad9-x-opendns-149e803734e5

https://news.ycombinator.com/item?id=16732820