### PR TITLE
update D7 release notes url

### DIFF
--- a/aegir/scripts/AegirSetupC.sh.txt
+++ b/aegir/scripts/AegirSetupC.sh.txt
@@ -1127,7 +1127,7 @@ drupal7_install() {
     || [[ "${_PLATFORMS_LIST}" =~ "D7S" ]] \
     || [[ "${_PLATFORMS_LIST}" =~ "D7P" ]]; then
     if [ ! -d "${_ROOT}/distro/${_THIS_CORE}/${_DRUPAL7D}" ]; then
-      if prompt_yes_no "$_F_DRUPAL7 - https://drupal.org/drupal-7.43-release-notes" ; then
+      if prompt_yes_no "$_F_DRUPAL7 - https://www.drupal.org/project/drupal/releases" ; then
         true
         ###---### Drupal 7 Development
         #


### PR DESCRIPTION
Just a minor install UI update. Current URL is hardcoded to Drupal 7.43.