### PR TITLE
Use GeoIP2 for GoAccess

### DIFF
--- a/aegir/tools/bin/weblogx
+++ b/aegir/tools/bin/weblogx
@@ -92,24 +92,6 @@ fetch_geoip() {
   mkdir -p /opt/tmp
   cd /opt/tmp
 
-# For IPv4 City database:
-  wget -q -U iCab \
-    http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
-  gunzip GeoLiteCity.dat.gz &> /dev/null
-  cp -af GeoLiteCity.dat /usr/share/GeoIP/
-
-# For IPv6 City database:
-  wget -q -U iCab \
-    http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz
-  gunzip GeoLiteCityv6.dat.gz &> /dev/null
-  cp -af GeoLiteCityv6.dat /usr/share/GeoIP/
-
-# For IPv6 Country database:
-  wget -q -U iCab \
-    http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
-  gunzip GeoIPv6.dat.gz &> /dev/null
-  cp -af GeoIPv6.dat /usr/share/GeoIP/
-
 # For GeoIP2 City database:
   wget -q -U iCab \
     wget -N http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz

--- a/aegir/tools/bin/weblogx
+++ b/aegir/tools/bin/weblogx
@@ -146,7 +146,7 @@ install_goaccess() {
     curl ${crlGet} "${urlDev}/src/goaccess-${_GOACCESS_VRN}.tar.gz" | tar -xzf -
     cd /var/opt/goaccess-${_GOACCESS_VRN}
   fi
-  bash ./configure --prefix=/usr --enable-utf8 --enable-geoip=legacy
+  bash ./configure --prefix=/usr --enable-utf8 --enable-geoip=mmdb
   make --quiet
   make --quiet install
   rm -rf /var/opt/goaccess*

--- a/aegir/tools/bin/weblogx
+++ b/aegir/tools/bin/weblogx
@@ -220,11 +220,11 @@ if_install() {
       echo 'sort-panel REFERRING_SITES,BY_VISITORS,DESC' >> /root/.goaccessrc
       echo 'sort-panel REQUESTS_STATIC,BY_VISITORS,DESC' >> /root/.goaccessrc
       echo 'sort-panel REQUESTS,BY_VISITORS,DESC' >> /root/.goaccessrc
-      if [ ! -e "/usr/share/GeoIP/GeoLiteCity.dat" ]; then
+      if [ ! -e "/usr/share/GeoIP/GeoLite2-City.mmdb" ]; then
         fetch_geoip
       fi
-      if [ -e "/usr/share/GeoIP/GeoLiteCity.dat" ]; then
-        echo 'geoip-database /usr/share/GeoIP/GeoLiteCity.dat' >> /root/.goaccessrc
+      if [ -e "/usr/share/GeoIP/GeoLite2-City.mmdb" ]; then
+        echo 'geoip-database /usr/share/GeoIP/GeoLite2-City.mmdb' >> /root/.goaccessrc
       fi
       echo 'html-prefs {"theme":"darkBlue","perPage":10,"visitors":{"plot":{"chartType":"bar"}},"visit_time":{"plot":{"chartType":"bar"}}}' >> /root/.goaccessrc
       rm -f /root/.goaccessrc.fix*

--- a/aegir/tools/system/graceful.sh
+++ b/aegir/tools/system/graceful.sh
@@ -47,24 +47,6 @@ action() {
   mkdir -p /opt/tmp
   cd /opt/tmp
 
-# For IPv4 City database:
-  wget -q -U iCab \
-    http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
-  gunzip GeoLiteCity.dat.gz &> /dev/null
-  cp -af GeoLiteCity.dat /usr/share/GeoIP/
-
-# For IPv6 City database:
-  wget -q -U iCab \
-    http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz
-  gunzip GeoLiteCityv6.dat.gz &> /dev/null
-  cp -af GeoLiteCityv6.dat /usr/share/GeoIP/
-
-# For IPv6 Country database:
-  wget -q -U iCab \
-    http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz
-  gunzip GeoIPv6.dat.gz &> /dev/null
-  cp -af GeoIPv6.dat /usr/share/GeoIP/
-
 # For GeoIP2 City database:
   wget -q -U iCab \
     wget -N http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz


### PR DESCRIPTION
Removing no longer available GeoLite Legacy databases and compiling GoAccess with support for mmdb (GeoLite2) databases.