### PR TITLE
add -y to `apt-get purge`, to avoid getting stuck on installation

### DIFF
--- a/lib/functions/system.sh.inc
+++ b/lib/functions/system.sh.inc
@@ -4641,7 +4641,7 @@ fix_postfix() {
     st_runner "${_RMAPP} exim4 exim4-base exim4-config sendmail \
                sendmail-base sendmail-cf sendmail-bin" &> /dev/null
     st_runner "apt-get purge exim4 exim4-base exim4-config sendmail \
-               sendmail-base sendmail-cf sendmail-bin" &> /dev/null
+               sendmail-base sendmail-cf sendmail-bin -y" &> /dev/null
     rm -f /etc/aliases
     rm -rf /etc/mail
     killall -9 sendmail &> /dev/null


### PR DESCRIPTION
On BOA head installation, it got stuck on step:
`BOA [14:05:19] ==> INFO: Installing required libraries and tools, please wait...`

Checking the Install log `/var/backups/barracuda-install-220610-130145.log`:
```
Reading package lists...
Building dependency tree...
Reading state information...
Package 'sendmail' is not installed, so not removed
Package 'sendmail-base' is not installed, so not removed
Package 'sendmail-bin' is not installed, so not removed
Package 'sendmail-cf' is not installed, so not removed
The following package was automatically installed and is no longer required:
  liblockfile1
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  bsd-mailx* exim4* exim4-base* exim4-config* exim4-daemon-light*
0 upgraded, 0 newly installed, 5 to remove and 0 not upgraded.
After this operation, 3973 kB disk space will be freed.
Do you want to continue? [Y/n] myServer:~#
```

The culprit is an `apt-get purge` without `-y`. 
Very weird because after tens of BOA installations, we never faced this issue until todat..

