### PR TITLE
Fix syntax error in php.sh.inc

### DIFF
--- a/lib/functions/php.sh.inc
+++ b/lib/functions/php.sh.inc
@@ -1309,7 +1309,7 @@ install_php_multi() {
   if [ "${_OSR}" = "chimaera" ] \
     || [ "${_OSR}" = "beowulf" ] \
     || [ "${_OSR}" = "bullseye" ] \
-    || [ "${_OSR}" = "buster" ] \
+    || [ "${_OSR}" = "buster" ]; then
     patchFile="freetype.patch"
     patch -p1 < ${bldPth}/aegir/patches/${patchFile} &> /dev/null
   fi


### PR DESCRIPTION
This corrects an error in an if statement in lib/functions/php.sh.inc introduced by commit cd09cee