### PR TITLE
Remove legacy _NEW_SSL check

### DIFF
--- a/aegir/tools/bin/randpass
+++ b/aegir/tools/bin/randpass
@@ -4,26 +4,6 @@ export HOME=/root
 export SHELL=/bin/bash
 export PATH=/usr/local/bin:/usr/local/sbin:/opt/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
 
-_OS_CODE=$(lsb_release -ar 2>/dev/null | grep -i codename | cut -s -f2 2>&1)
-if [ -e "/root/.install.modern.openssl.cnf" ] \
-  && [ -x "/usr/local/ssl3/bin/openssl" ]; then
-  _SSL_BINARY=/usr/local/ssl3/bin/openssl
-else
-  _SSL_BINARY=/usr/local/ssl/bin/openssl
-fi
-_SSL_ITD=$(${_SSL_BINARY} version 2>&1 \
-  | tr -d "\n" \
-  | cut -d" " -f2 \
-  | awk '{ print $1}')
-if [[ "${_SSL_ITD}" =~ "3.3." ]] \
-  || [[ "${_SSL_ITD}" =~ "3.2." ]] \
-  || [[ "${_SSL_ITD}" =~ "3.1." ]] \
-  || [[ "${_SSL_ITD}" =~ "3.0." ]] \
-  || [[ "${_SSL_ITD}" =~ "1.1." ]] \
-  || [[ "${_SSL_ITD}" =~ "1.0." ]]; then
-  _NEW_SSL=YES
-fi
-
 _randpass() {
   if [ "${_integer}" -ge "32" ]; then
     _rkey="${_integer}"
@@ -45,20 +25,12 @@ _randpass() {
       | sed 's/[\\\/\^\?\>\`\#\"\{\(\$\@\&\|\*]//g; s/\(['"'"'\]\)//g'
   elif [ "${_kind}" = "hash" ]; then
     _CHAR="[:alnum:]"
-    if [ "${_NEW_SSL}" = "YES" ]; then
-      cat /dev/urandom \
-        | tr -cd "${_CHAR}" \
-        | head -c ${1:-${_rkey}} \
-        | openssl md5 \
-        | awk '{ print $2}' \
-        | tr -d "\n"
-    else
-      cat /dev/urandom \
-        | tr -cd "${_CHAR}" \
-        | head -c ${1:-${_rkey}} \
-        | openssl md5 \
-        | tr -d "\n"
-    fi
+    cat /dev/urandom \
+      | tr -cd "${_CHAR}" \
+      | head -c ${1:-${_rkey}} \
+      | openssl md5 \
+      | awk '{ print $2}' \
+      | tr -d "\n"
   else
     _CHAR="[:alnum:]"
     cat /dev/urandom \

--- a/aegir/tools/system/daily.sh
+++ b/aegir/tools/system/daily.sh
@@ -37,26 +37,6 @@ if [ -e "/root/.pause_heavy_tasks_maint.cnf" ]; then
 fi
 
 _WEBG=www-data
-_OS_CODE=$(lsb_release -ar 2>/dev/null | grep -i codename | cut -s -f2 2>&1)
-
-if [ -e "/root/.install.modern.openssl.cnf" ] \
-  && [ -x "/usr/local/ssl3/bin/openssl" ]; then
-  _SSL_BINARY=/usr/local/ssl3/bin/openssl
-else
-  _SSL_BINARY=/usr/local/ssl/bin/openssl
-fi
-_SSL_ITD=$(${_SSL_BINARY} version 2>&1 \
-  | tr -d "\n" \
-  | cut -d" " -f2 \
-  | awk '{ print $1}')
-if [[ "${_SSL_ITD}" =~ "3.3." ]] \
-  || [[ "${_SSL_ITD}" =~ "3.2." ]] \
-  || [[ "${_SSL_ITD}" =~ "3.1." ]] \
-  || [[ "${_SSL_ITD}" =~ "3.0." ]] \
-  || [[ "${_SSL_ITD}" =~ "1.1." ]] \
-  || [[ "${_SSL_ITD}" =~ "1.0." ]]; then
-  _NEW_SSL=YES
-fi
 _crlGet="-L --max-redirs 3 -k -s --retry 9 --retry-delay 9 -A iCab"
 _wgetGet="--max-redirect=3 --no-check-certificate -q --tries=9 --wait=9 --user-agent='iCab'"
 _aptAllow="--allow-unauthenticated"
@@ -2310,16 +2290,10 @@ _daily_process() {
         | sed "s/[\,']//g" 2>&1)
       _PLR_CTRL_F="${_Plr}/sites/all/modules/boa_platform_control.ini"
       if [ -e "${_Plr}" ]; then
-        if [ "${_NEW_SSL}" = "YES" ]; then
-          _PlrID=$(echo ${_Plr} \
-            | openssl md5 \
-            | awk '{ print $2}' \
-            | tr -d "\n" 2>&1)
-        else
-          _PlrID=$(echo ${_Plr} \
-            | openssl md5 \
-            | tr -d "\n" 2>&1)
-        fi
+        _PlrID=$(echo ${_Plr} \
+          | openssl md5 \
+          | awk '{ print $2}' \
+          | tr -d "\n" 2>&1)
         _codeBaseCheckInfo="${_usEr}/log/ctrl/plr.${_PlrID}.codebasecheck-${_NOW}.info"
         if [ -x "/opt/local/bin/codebasecheck" ] && [ ! -f "${_codeBaseCheckInfo}" ]; then
           codebasecheck ${_Plr}


### PR DESCRIPTION
Boa 5.x-lts is still running a check for '_NEW_SSL', but this is no longer working correctly because it only checks for SSL versions from 1.0 to 3.3, while 5.x-lts currently uses version 3.4.1. As a result of this, the daily.sh script creates the wrong file permissions for sites in the 'static' directory, as reported in #1860

This PR removes the legacy _NEW_SSL check for 5.x-lts in line with that has already been done for 5.x-dev and 5.x-pro in commit 76f2dc3